### PR TITLE
refactor(ci): remove GitHub release update step from publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -74,28 +74,6 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          
-      - name: Create GitHub Release Notes
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
-
-            const { data: release } = await github.rest.repos.getReleaseByTag({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag: context.ref.replace('refs/tags/', '')
-            });
-
-            const publishInfo = `\n\n## 📦 Published to npm\n\n\`\`\`bash\nnpm install ${packageJson.name}@${packageJson.version}\n\`\`\`\n\n🔗 View on npm: https://www.npmjs.com/package/${packageJson.name}/v/${packageJson.version}\n\n✅ All quality checks passed\n- Prettier format check\n- TypeScript compilation\n- All 797 tests passed\n- Build artifacts verified`;
-
-            await github.rest.repos.updateRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: release.id,
-              body: release.body ? `${release.body}${publishInfo}` : publishInfo.trim()
-            });
 
       - name: Publish Success
         run: |


### PR DESCRIPTION
## Summary
Removes the non-critical "Create GitHub Release Notes" step from the npm publish workflow that fails due to permission issues.

## Problem
The publish workflow has a final step that tries to update the GitHub release description with npm package information. This step fails with:
```
HttpError: Resource not accessible by integration (403)
```

While the failure doesn't affect npm publishing (which succeeds), it makes the workflow appear failed.

## Changes Made

### Removed Step
The "Create GitHub Release Notes" step that:
- Fetched the release using `getReleaseByTag`
- Appended npm publish information to the release body
- Updated the release using `updateRelease` (caused the 403 error)

### What Remains
- ✅ All critical steps (checkout, build, test, publish) unchanged
- ✅ "Publish Success" logging step kept for workflow output
- ✅ Workflow now ends cleanly after successful npm publish

## Why This Is Safe

**Runs After Critical Steps:**
- ✅ npm publish already succeeded before this step
- ✅ All tests passed
- ✅ Package already live on npm

**No Functional Impact:**
- ✅ Only updated release description text (cosmetic)
- ✅ npm package information already in release notes manually
- ✅ No user or package impact

## Benefits

1. **Simpler workflow** - Removed unnecessary complexity
2. **Eliminates permission errors** - No more 403 failures
3. **More reliable** - Workflow shows success when publish succeeds
4. **Reduces maintenance** - One less thing to maintain

## Testing

- ✅ YAML syntax validated
- ✅ No orphaned references
- ✅ Workflow structure remains valid
- ✅ All indentation preserved

The workflow will be fully tested on the next release.

## Migration

No migration needed - this is a workflow-only change with no impact on package or users.

Closes #68