### PR TITLE
chore(release): bump version to 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-04-28
+
+### Added
+
+- Comprehensive Portugal (PRT) Cartão de Cidadão (CC) validation tests — valid format coverage, first/second check digit validation, invalid length, character position, and format edge cases ([#34](https://github.com/identique/idnumbers-npm/issues/34))
+- Comprehensive Portugal (PRT) NIF (Número de Identificação Fiscal) validation tests — individual/legal entity/public entity/other type prefixes, modulus 11 checksum, invalid first digit, length, and character handling ([#35](https://github.com/identique/idnumbers-npm/issues/35))
+- Portugal (PRT) parse() and edge case tests — CC and NIF component extraction, entity type identification, input handling (null/undefined/empty/whitespace), format variations (spaces, dashes, mixed case), and error paths ([#36](https://github.com/identique/idnumbers-npm/issues/36))
+
 ## [1.7.0] - 2026-04-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idnumbers",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "A TypeScript library for verifying and parsing national ID numbers - supports 80 countries across 6 continents including USA, UK, France, Germany, Japan, China, India, Brazil, and many more",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Cuts the v1.8.0 release — test coverage sweep for Portugal (PRT) Cartão de Cidadão, NIF, and parse/edge cases.

Closes milestone [v1.8.0](https://github.com/identique/idnumbers-npm/milestone/7).

## Changes

- Bump `package.json`: `1.7.0` → `1.8.0`
- Add `[1.8.0] - 2026-04-28` section to `CHANGELOG.md`

## Included work (already merged on `main`)

- #34 — Portugal Cartão de Cidadão (CC) validation tests
- #35 — Portugal NIF (tax number) validation tests
- #36 — Portugal parse() and edge case tests

Order followed the dependency plan posted on the issues: `#34 ∥ #35 → #36`.

## Release notes (preview)

### Added

- Comprehensive Portugal (PRT) Cartão de Cidadão (CC) validation tests — valid format coverage, first/second check digit validation, invalid length, character position, and format edge cases (#34)
- Comprehensive Portugal (PRT) NIF (Número de Identificação Fiscal) validation tests — individual/legal entity/public entity/other type prefixes, modulus 11 checksum, invalid first digit, length, and character handling (#35)
- Portugal (PRT) parse() and edge case tests — CC and NIF component extraction, entity type identification, input handling (null/undefined/empty/whitespace), format variations (spaces, dashes, mixed case), and error paths (#36)

## Test plan

- [x] `npm run format:check` — clean
- [x] `npm run build` — TSC clean
- [x] `npm test` — 1740 tests pass across 21 suites
- [x] Pre-commit hook green (Prettier + TSC + Jest)
- [ ] CI green on PR
- [ ] After merge: tag `v1.8.0` + create GitHub Release → `npm-publish.yml` auto-publishes to npm

## Notes

- Branch name intentionally `chore/release-v1.8.0` (matching the v1.7.0 release pattern) — the `release/*` ruleset blocks initial push by requiring status checks before the branch exists.