### PR TITLE
docs(#15): research Bahrain CPR checksum + pin format-only vectors

### DIFF
--- a/docs/research/bahrain-cpr-checksum.md
+++ b/docs/research/bahrain-cpr-checksum.md
@@ -88,7 +88,7 @@ The checksum digit is **not verified** (algorithm unknown).
 | `000101001` | `00` | `01` | `0100` | `1` | year-2000-or-2100 ambiguity is OK    |
 | `991231999` | `99` | `12` | `3199` | `9` | boundary month + high serial         |
 | `120615432` | `12` | `06` | `1543` | `2` |                                      |
-| `850714210` | `85` | `07` | `4210` | `0` | zero check digit                     |
+| `850714210` | `85` | `07` | `1421` | `0` | zero check digit                     |
 
 ### Format-invalid examples
 

--- a/docs/research/bahrain-cpr-checksum.md
+++ b/docs/research/bahrain-cpr-checksum.md
@@ -1,0 +1,142 @@
+# Bahrain CPR Checksum — Research Record
+
+> Issue: [#15](https://github.com/identique/idnumbers-npm/issues/15) — milestone v1.9.0
+> Deliverable for: research(bhr) — Bahrain Central Population Registry (CPR) checksum algorithm
+
+## Status
+
+Research complete — checksum algorithm not publicly available (as of 2026-05-21).
+
+## Format
+
+The Bahrain Personal Number (also: Identification Card Number, CPR, الرقم الشخصي) is exactly **9 digits**, decomposed as:
+
+| Field  | Length | Description                                                          |
+| ------ | ------ | -------------------------------------------------------------------- |
+| `YY`   | 2      | Year-of-birth, two-digit (no century qualifier in the number)        |
+| `MM`   | 2      | Month-of-birth, `01`–`12` (`00` and `13`+ are rejected by the regex) |
+| `SSSS` | 4      | Serial number, `0000`–`9999`                                         |
+| `C`    | 1      | Check digit, `0`–`9` (algorithm unknown — see below)                 |
+
+Regex enforced by the validator (`src/countries/bhr/personal-number.ts`):
+
+```
+^(?<yymm>\d{2}(?:0[1-9]|1[012]))(?<sn>\d{4})(?<checksum>\d)$
+```
+
+## Checksum algorithm
+
+**No publicly documented algorithm was located.** Wikipedia's
+["National identification number" § Bahrain](https://en.wikipedia.org/wiki/National_identification_number#Bahrain)
+section notes that a check digit exists but provides no algorithmic detail
+(modulus, weights, Luhn/Verhoeff variant, etc.).
+
+The Python upstream that this repository ports from (`Identique/idnumbers`)
+carries the same gap. In
+[`idnumbers/nationalid/bhr/personal_number.py`](https://github.com/Identique/idnumbers/blob/main/idnumbers/nationalid/bhr/personal_number.py)
+the `parse()` method contains an identical placeholder:
+
+```python
+# TODO: find and implement checksum
+return {
+    'yymm': match_obj.group('yymm'),
+    'sn': match_obj.group('sn'),
+    'checksum': int(match_obj.group('checksum'))
+}
+```
+
+…and the class metadata declares `'checksum': False`. The TypeScript port matches
+that contract: `METADATA.checksum: false` with format-only validation.
+
+## Decision
+
+**Do not implement a checksum.** Keep `METADATA.checksum = false` and format-only
+validation until a citable algorithm specification or a set of verified
+checksum-valid test vectors becomes available. Implementing a guessed algorithm
+would diverge from the Python upstream (which CLAUDE.md mandates parity with)
+and would either reject real CPRs or accept invalid ones — both worse than the
+current honest "format-only" stance.
+
+## Synthetic-data notice
+
+The example numbers below are **synthetic / not knowingly real personal
+identifiers**. They are intended only to exercise format validation. Real
+Bahraini CPRs are sensitive personal data and are not used here.
+
+## Sources consulted
+
+| Source                                                                                                | Result                                        |
+| ----------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| Wikipedia — National identification number § Bahrain (accessed 2026-05-21)                            | Mentions a check digit; no algorithm provided |
+| Bahrain Information & eGovernment Authority (iGA) public portals (accessed 2026-05-21)                | No technical specification published          |
+| [`Identique/idnumbers`](https://github.com/Identique/idnumbers) — `nationalid/bhr/personal_number.py` | Identical `TODO`; `checksum: False`           |
+| `python-stdnum` (`stdnum` package)                                                                    | No Bahrain CPR module                         |
+| `stdnum-js`                                                                                           | No Bahrain CPR module                         |
+| Academic papers / open-source surveys of national ID systems                                          | No algorithm description for Bahrain CPR      |
+
+## Test vectors
+
+### Format-only accepted examples
+
+These IDs satisfy the regex above and are accepted by the current validator.
+The checksum digit is **not verified** (algorithm unknown).
+
+| CPR         | `YY` | `MM` | `SSSS` | `C` | Notes                                |
+| ----------- | ---- | ---- | ------ | --- | ------------------------------------ |
+| `800101001` | `80` | `01` | `0100` | `1` | canonical example used across suites |
+| `900101001` | `90` | `01` | `0100` | `1` |                                      |
+| `000101001` | `00` | `01` | `0100` | `1` | year-2000-or-2100 ambiguity is OK    |
+| `991231999` | `99` | `12` | `3199` | `9` | boundary month + high serial         |
+| `120615432` | `12` | `06` | `1543` | `2` |                                      |
+| `850714210` | `85` | `07` | `4210` | `0` | zero check digit                     |
+
+### Format-invalid examples
+
+| Input        | Reason               |
+| ------------ | -------------------- |
+| `80010100`   | 8 digits (too short) |
+| `8001010012` | 10 digits (too long) |
+| `801301001`  | month `13` invalid   |
+| `800001001`  | month `00` invalid   |
+| `8001A1001`  | non-digit character  |
+| `''` (empty) | empty string         |
+
+## Future work
+
+If the Bahrain CPR checksum algorithm is later published or contributed back,
+**both** the Python upstream and this TypeScript port should adopt it in
+lock-step. When that happens:
+
+- Update `METADATA.checksum` to `true` in `src/countries/bhr/personal-number.ts`.
+- Implement the algorithm inside `parse()` / `validate()`.
+- **Revise the test vectors in `src/__tests__/issue-15-bhr-research.test.ts`** —
+  most synthetic IDs above will likely fail a real check digit and must be
+  replaced with verified-valid examples.
+- Update this document's Status, Decision, and Test vectors sections.
+
+## Implementation status (2026-05-21)
+
+- `src/countries/bhr/personal-number.ts` — format-only validation, `METADATA.checksum: false`.
+- Parity with Python upstream is intact.
+- Vectors above are pinned in `src/__tests__/issue-15-bhr-research.test.ts`.
+
+## Verification commands
+
+```bash
+npm test -- --runTestsByPath src/__tests__/issue-15-bhr-research.test.ts
+npm test
+npm run build
+npm run format:check
+```
+
+## Call for contributions
+
+Developers with access to Bahrain's official CPR technical specification (iGA or
+related agencies) — please open a PR or issue with citations. Even partial
+information (algorithm family, weights, modulus) would unblock implementation.
+
+## References
+
+- Issue tracker: <https://github.com/identique/idnumbers-npm/issues/15>
+- Python upstream: <https://github.com/Identique/idnumbers/blob/main/idnumbers/nationalid/bhr/personal_number.py>
+- Wikipedia: <https://en.wikipedia.org/wiki/National_identification_number#Bahrain>

--- a/src/__tests__/issue-15-bhr-research.test.ts
+++ b/src/__tests__/issue-15-bhr-research.test.ts
@@ -18,6 +18,9 @@
 import { PersonalNumber } from '../countries/bhr/personal-number';
 import { validateNationalId, parseIdInfo } from '../index';
 
+const CANONICAL_ID = '800101001';
+const CANONICAL_PARSED = { yymm: '8001', sn: '0100', checksum: 1 };
+
 describe('BHR Personal Number (CPR) — issue #15 research vectors', () => {
   describe('format-only accepted examples (current Python-compatible behavior)', () => {
     it.each(['800101001', '900101001', '000101001', '991231999', '120615432', '850714210'])(
@@ -30,11 +33,7 @@ describe('BHR Personal Number (CPR) — issue #15 research vectors', () => {
     );
 
     it('extractedInfo equals direct parse() for the canonical example', () => {
-      expect(validateNationalId('BHR', '800101001').extractedInfo).toEqual({
-        yymm: '8001',
-        sn: '0100',
-        checksum: 1,
-      });
+      expect(validateNationalId('BHR', CANONICAL_ID).extractedInfo).toEqual(CANONICAL_PARSED);
     });
   });
 
@@ -62,29 +61,17 @@ describe('BHR Personal Number (CPR) — issue #15 research vectors', () => {
     });
 
     it('parse() exposes yymm/sn/checksum fields', () => {
-      expect(PersonalNumber.parse('800101001')).toEqual({
-        yymm: '8001',
-        sn: '0100',
-        checksum: 1,
-      });
+      expect(PersonalNumber.parse(CANONICAL_ID)).toEqual(CANONICAL_PARSED);
     });
   });
 
   describe('registry-path parseIdInfo (BHR + BH alias)', () => {
     it('parseIdInfo("BHR", ...) returns parsed fields', () => {
-      expect(parseIdInfo('BHR', '800101001')).toEqual({
-        yymm: '8001',
-        sn: '0100',
-        checksum: 1,
-      });
+      expect(parseIdInfo('BHR', CANONICAL_ID)).toEqual(CANONICAL_PARSED);
     });
 
     it('parseIdInfo("BH", ...) resolves via alias to the same result', () => {
-      expect(parseIdInfo('BH', '800101001')).toEqual({
-        yymm: '8001',
-        sn: '0100',
-        checksum: 1,
-      });
+      expect(parseIdInfo('BH', CANONICAL_ID)).toEqual(CANONICAL_PARSED);
     });
 
     it('parseIdInfo returns null for format-invalid input', () => {

--- a/src/__tests__/issue-15-bhr-research.test.ts
+++ b/src/__tests__/issue-15-bhr-research.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Issue #15 — Bahrain CPR checksum research (milestone v1.9.0).
+ *
+ * Scope: documentation + comment cleanup only. No production code changes.
+ *
+ * Pins the test vectors documented in `docs/research/bahrain-cpr-checksum.md`
+ * and locks the Python-parity contract (no checksum implementation, format-only).
+ * The Python upstream `idnumbers/nationalid/bhr/personal_number.py` carries an
+ * identical TODO and `checksum: False`; this file asserts the TS port stays in
+ * lock-step.
+ *
+ * Three IDs (`800101001`, `900101001`, `000101001`) intentionally overlap with
+ * `comprehensive-validation.test.ts` — overlap is by design so deletions there
+ * cannot silently drop the research vectors.
+ *
+ * Issue: https://github.com/identique/idnumbers-npm/issues/15
+ */
+import { PersonalNumber } from '../countries/bhr/personal-number';
+import { validateNationalId, parseIdInfo } from '../index';
+
+describe('BHR Personal Number (CPR) — issue #15 research vectors', () => {
+  describe('format-only accepted examples (current Python-compatible behavior)', () => {
+    it.each(['800101001', '900101001', '000101001', '991231999', '120615432', '850714210'])(
+      '%s passes format validation',
+      id => {
+        expect(PersonalNumber.validate(id)).toBe(true);
+        expect(validateNationalId('BHR', id).isValid).toBe(true);
+        expect(validateNationalId('BH', id).isValid).toBe(true);
+      }
+    );
+
+    it('extractedInfo equals direct parse() for the canonical example', () => {
+      expect(validateNationalId('BHR', '800101001').extractedInfo).toEqual({
+        yymm: '8001',
+        sn: '0100',
+        checksum: 1,
+      });
+    });
+  });
+
+  describe('format-invalid examples', () => {
+    it.each([
+      ['80010100', 'too short'],
+      ['8001010012', 'too long'],
+      ['801301001', 'invalid month 13'],
+      ['800001001', 'invalid month 00'],
+      ['8001A1001', 'non-digit character'],
+      ['', 'empty string'],
+    ])('%s rejected (%s)', id => {
+      expect(PersonalNumber.validate(id)).toBe(false);
+      expect(PersonalNumber.parse(id)).toBeNull();
+    });
+  });
+
+  describe('metadata + Python-parity contract', () => {
+    it('METADATA.checksum is false (matches Python upstream)', () => {
+      expect(PersonalNumber.METADATA.checksum).toBe(false);
+    });
+
+    it('METADATA.parsable is true', () => {
+      expect(PersonalNumber.METADATA.parsable).toBe(true);
+    });
+
+    it('parse() exposes yymm/sn/checksum fields', () => {
+      expect(PersonalNumber.parse('800101001')).toEqual({
+        yymm: '8001',
+        sn: '0100',
+        checksum: 1,
+      });
+    });
+  });
+
+  describe('registry-path parseIdInfo (BHR + BH alias)', () => {
+    it('parseIdInfo("BHR", ...) returns parsed fields', () => {
+      expect(parseIdInfo('BHR', '800101001')).toEqual({
+        yymm: '8001',
+        sn: '0100',
+        checksum: 1,
+      });
+    });
+
+    it('parseIdInfo("BH", ...) resolves via alias to the same result', () => {
+      expect(parseIdInfo('BH', '800101001')).toEqual({
+        yymm: '8001',
+        sn: '0100',
+        checksum: 1,
+      });
+    });
+
+    it('parseIdInfo returns null for format-invalid input', () => {
+      expect(parseIdInfo('BHR', '80010100')).toBeNull();
+    });
+  });
+});

--- a/src/__tests__/parseIdInfo-migration.test.ts
+++ b/src/__tests__/parseIdInfo-migration.test.ts
@@ -306,7 +306,7 @@ describe('createValidator', () => {
         links: [],
         deprecated: false,
       },
-      validate: (_id: string) => true,
+      validate: () => true,
     };
     const validator = createValidator(mockNoparse);
     expect(validator.parse).toBeUndefined();

--- a/src/__tests__/registry.test.ts
+++ b/src/__tests__/registry.test.ts
@@ -1,5 +1,5 @@
 import { ValidatorRegistry, registry } from '../registry';
-import type { CountryValidator, IdFormat } from '../registry';
+import type { CountryValidator } from '../registry';
 import type { IdMetadata } from '../types';
 
 // ---------------------------------------------------------------------------

--- a/src/countries/bhr/personal-number.ts
+++ b/src/countries/bhr/personal-number.ts
@@ -9,9 +9,12 @@ export type ParseResult = {
 };
 
 /**
- * Bahrain Personal Number, Identification Card Number, Arabic:  الرقم الشخصي
+ * Bahrain Personal Number / Identification Card Number (CPR) — الرقم الشخصي.
+ * Format: YYMMSSSSC (9 digits). A check digit (C) exists but the official
+ * algorithm is not publicly documented; validation is format-only, matching
+ * the Python upstream (`idnumbers/nationalid/bhr/personal_number.py`).
+ * See `docs/research/bahrain-cpr-checksum.md` for the research record.
  * https://en.wikipedia.org/wiki/National_identification_number#Bahrain
- * * According to the doc, we can know it has checksum algorithm. But we cannot find it.
  */
 export class PersonalNumber {
   public static METADATA: IMetadata = {
@@ -20,9 +23,7 @@ export class PersonalNumber {
     maxLength: 9,
     parsable: true,
     checksum: false,
-    regexp: new RegExp(
-      /^(?<yymm>\d{2}(?:0[1-9]|1[012]))(?<sn>\d{4})(?<checksum>\d)$/
-    ),
+    regexp: new RegExp(/^(?<yymm>\d{2}(?:0[1-9]|1[012]))(?<sn>\d{4})(?<checksum>\d)$/),
     aliasOf: null,
     names: [
       'Personal number',
@@ -50,7 +51,7 @@ export class PersonalNumber {
       return null;
     }
 
-    // TODO: find and implement checksum
+    // Checksum algorithm not publicly documented; see docs/research/bahrain-cpr-checksum.md.
     return {
       yymm: match.groups!.yymm,
       sn: match.groups!.sn,


### PR DESCRIPTION
Closes #15 (milestone v1.9.0).

## Summary

Issue #15 asked to research the Bahrain CPR check-digit algorithm and ship a markdown deliverable + test vectors. Research was completed in the issue comments (algorithm **not publicly documented**; Python upstream `idnumbers/nationalid/bhr/personal_number.py` carries the identical `# TODO: find and implement checksum`), but the referenced `docs/research/bahrain-cpr-checksum.md` was never committed. This PR delivers the missing artifact, pins it against the validator with a Jest file, and tightens the BHR source comments.

**No runtime change** to `PersonalNumber.validate` / `parse` / `METADATA` — implementing a guessed checksum would diverge from the Python upstream (CLAUDE.md mandates parity).

## Changes

- **`docs/research/bahrain-cpr-checksum.md`** (new, 142 lines) — research record with: format spec, sources consulted (Wikipedia, iGA, python-stdnum, stdnum-js, Python upstream — all with access dates), explicit Decision (keep `METADATA.checksum: false`), synthetic-data notice, 6 format-only accepted vectors, 6 format-invalid vectors, future-work guidance, verification commands, and call for community contributions.
- **`src/countries/bhr/personal-number.ts`** (comments only) — class JSDoc rewritten to cite the research doc + Python parity; the bare `// TODO: find and implement checksum` replaced with a pointer to the research doc.
- **`src/__tests__/issue-15-bhr-research.test.ts`** (new, 81 lines / 19 tests across 4 `describe` blocks) — pins the documented vectors, the canonical `parse()` shape, the `METADATA.checksum=false / parsable=true` contract, and the registry path (both `BHR` primary key and `BH` alias) so the doc cannot silently drift from the validator.
- **Ride-along chore** — removed 2 pre-existing `no-unused-vars` lint errors in `src/__tests__/parseIdInfo-migration.test.ts` and `src/__tests__/registry.test.ts` (surfaced when CI ran the new branch; user-approved scope creep).

## Commits

- `6227a5c` docs(#15): add Bahrain CPR checksum research record
- `4991df5` test(#15): pin Bahrain CPR research vectors and clarify checksum comments
- `1ac424f` chore(#15): drop unused lint identifiers
- `b4bf8f4` refactor(#15): extract canonical id/parsed constants in BHR research test
- `6a09cbb` docs(#15): fix SSSS decomposition for 850714210 in research vector table

## Test plan

- [x] `npm test -- --runTestsByPath src/__tests__/issue-15-bhr-research.test.ts` — 19 new tests pass
- [x] `npm test` — 22 suites / 1759 tests pass (incl. the `registry.list().length === 80` hard assertion)
- [x] `npm run build` — clean
- [x] `npm run format:check` — clean
- [x] `npm run lint` — clean
- [x] Husky pre-commit hook ran on every commit
- [x] Internal reviewer agent — APPROVED (1 P2 doc-typo fixed)
- [x] External independent review (Manual + 5-agent Multi-Perspective + Codex/gpt-5.5, all run cold) — APPROVED, 0 P0 / 0 P1, scores 10/10/9/10

## Notes for reviewers

- Three IDs (`800101001`, `900101001`, `000101001`) intentionally overlap with `comprehensive-validation.test.ts`. The new test file's header documents this — overlap is a feature (drift-prevention), not duplication.
- The research doc is repo-internal: `package.json#files` does not include `docs/`, so it will not ship to npm consumers.
- If the algorithm is ever published upstream, the future-work section names `src/__tests__/issue-15-bhr-research.test.ts` as the single point of revision.