### PR TITLE
test(#17): expand BHR coverage with null/undefined, boundary, and parse-contract cases

### DIFF
--- a/src/__tests__/issue-15-bhr-research.test.ts
+++ b/src/__tests__/issue-15-bhr-research.test.ts
@@ -110,7 +110,7 @@ describe('BHR Personal Number (CPR) — issue #17 additional coverage', () => {
   describe('format boundary cases (YYMM + serial extremes — all expected valid)', () => {
     // Bahrain CPR encodes only year+month, not day; serial 0000–9999 is unconstrained.
     it.each([
-      ['000101000', 'year 00, month 01 (lower-bound month), serial 0000'],
+      ['000100000', 'year 00, month 01 (lower-bound month), serial 0000'],
       ['991201999', 'year 99 (upper-bound year), month 12 (upper-bound month)'],
       ['000999990', 'year 00, month 09, serial 9999 (upper-bound serial)'],
       ['501012345', 'mid-range typical value'],

--- a/src/__tests__/issue-15-bhr-research.test.ts
+++ b/src/__tests__/issue-15-bhr-research.test.ts
@@ -97,12 +97,11 @@ describe('BHR Personal Number (CPR) — issue #17 additional coverage', () => {
       expect(PersonalNumber.validate(input as unknown as string)).toBe(false);
     });
 
-    it('parse() returns null for null input', () => {
-      expect(PersonalNumber.parse(null as unknown as string)).toBeNull();
-    });
-
-    it('parse() returns null for undefined input', () => {
-      expect(PersonalNumber.parse(undefined as unknown as string)).toBeNull();
+    it.each<[string, null | undefined]>([
+      ['null', null],
+      ['undefined', undefined],
+    ])('parse() returns null for %s input', (_label, input) => {
+      expect(PersonalNumber.parse(input as unknown as string)).toBeNull();
     });
 
     it('validateNationalId rejects null via registry', () => {

--- a/src/__tests__/issue-15-bhr-research.test.ts
+++ b/src/__tests__/issue-15-bhr-research.test.ts
@@ -88,14 +88,12 @@ describe('BHR Personal Number (CPR) — issue #15 research vectors', () => {
 
 describe('BHR Personal Number (CPR) — issue #17 additional coverage', () => {
   describe('falsy and non-string inputs', () => {
-    it.each<[string | null | undefined]>([
-      [null],
-      [undefined],
-      [' '],
-      ['  800101001  '],
-    ])('validate rejects %s', input => {
-      expect(PersonalNumber.validate(input as unknown as string)).toBe(false);
-    });
+    it.each<[string | null | undefined]>([[null], [undefined], [' '], ['  800101001  ']])(
+      'validate rejects %s',
+      input => {
+        expect(PersonalNumber.validate(input as unknown as string)).toBe(false);
+      }
+    );
 
     it.each<[string, null | undefined]>([
       ['null', null],

--- a/src/__tests__/issue-15-bhr-research.test.ts
+++ b/src/__tests__/issue-15-bhr-research.test.ts
@@ -88,7 +88,7 @@ describe('BHR Personal Number (CPR) — issue #15 research vectors', () => {
 
 describe('BHR Personal Number (CPR) — issue #17 additional coverage', () => {
   describe('falsy and non-string inputs', () => {
-    it.each<[string | null | undefined]>([[null], [undefined], [' '], ['  800101001  ']])(
+    it.each<[string | null | undefined]>([[null], [undefined], [' ']])(
       'validate rejects %s',
       input => {
         expect(PersonalNumber.validate(input as unknown as string)).toBe(false);
@@ -111,7 +111,7 @@ describe('BHR Personal Number (CPR) — issue #17 additional coverage', () => {
     // Bahrain CPR encodes only year+month, not day; serial 0000–9999 is unconstrained.
     it.each([
       ['000101000', 'year 00, month 01 (lower-bound month), serial 0000'],
-      ['991201999', 'year 99, month 12 (upper-bound month), serial 1999'],
+      ['991201999', 'year 99 (upper-bound year), month 12 (upper-bound month)'],
       ['000999990', 'year 00, month 09, serial 9999 (upper-bound serial)'],
       ['501012345', 'mid-range typical value'],
     ])('%s is format-valid (%s)', id => {

--- a/src/__tests__/issue-15-bhr-research.test.ts
+++ b/src/__tests__/issue-15-bhr-research.test.ts
@@ -14,6 +14,12 @@
  * cannot silently drop the research vectors.
  *
  * Issue: https://github.com/identique/idnumbers-npm/issues/15
+ *
+ * Issue #17 (https://github.com/identique/idnumbers-npm/issues/17) extends this
+ * file with null/undefined, format-boundary, edge-case, and parse-contract
+ * coverage. Checksum and gender tests are intentionally omitted: the Bahrain
+ * CPR checksum algorithm is not publicly documented (see #15), and the CPR
+ * format `YYMMSSSSC` does not encode gender.
  */
 import { PersonalNumber } from '../countries/bhr/personal-number';
 import { validateNationalId, parseIdInfo } from '../index';
@@ -76,6 +82,91 @@ describe('BHR Personal Number (CPR) — issue #15 research vectors', () => {
 
     it('parseIdInfo returns null for format-invalid input', () => {
       expect(parseIdInfo('BHR', '80010100')).toBeNull();
+    });
+  });
+});
+
+describe('BHR Personal Number (CPR) — issue #17 additional coverage', () => {
+  describe('falsy and non-string inputs', () => {
+    it.each<[string | null | undefined]>([
+      [null],
+      [undefined],
+      [' '],
+      ['  800101001  '],
+    ])('validate rejects %s', input => {
+      expect(PersonalNumber.validate(input as unknown as string)).toBe(false);
+    });
+
+    it('parse() returns null for null input', () => {
+      expect(PersonalNumber.parse(null as unknown as string)).toBeNull();
+    });
+
+    it('parse() returns null for undefined input', () => {
+      expect(PersonalNumber.parse(undefined as unknown as string)).toBeNull();
+    });
+
+    it('validateNationalId rejects null via registry', () => {
+      expect(validateNationalId('BHR', null as unknown as string).isValid).toBe(false);
+    });
+  });
+
+  describe('format boundary cases (YYMM + serial extremes — all expected valid)', () => {
+    // Bahrain CPR encodes only year+month, not day; serial 0000–9999 is unconstrained.
+    it.each([
+      ['000101000', 'year 00, month 01 (lower-bound month), serial 0000'],
+      ['991201999', 'year 99, month 12 (upper-bound month), serial 1999'],
+      ['000999990', 'year 00, month 09, serial 9999 (upper-bound serial)'],
+      ['501012345', 'mid-range typical value'],
+    ])('%s is format-valid (%s)', id => {
+      expect(PersonalNumber.validate(id)).toBe(true);
+      expect(validateNationalId('BHR', id).isValid).toBe(true);
+    });
+  });
+
+  describe('format edge cases — surrounding whitespace and structure', () => {
+    it.each([
+      [' 800101001', 'leading space'],
+      ['800101001 ', 'trailing space'],
+      ['800-101-001', 'hyphenated'],
+      ['8001010ab', 'trailing letters'],
+      ['8001010 1', 'embedded space'],
+    ])('%s is rejected (%s)', id => {
+      expect(PersonalNumber.validate(id)).toBe(false);
+    });
+  });
+
+  describe('parse output contract', () => {
+    const parsed = PersonalNumber.parse(CANONICAL_ID);
+
+    it('parsed result is not null', () => {
+      expect(parsed).not.toBeNull();
+    });
+
+    it('yymm is a 4-char digit string', () => {
+      expect(typeof parsed!.yymm).toBe('string');
+      expect(parsed!.yymm).toHaveLength(4);
+      expect(parsed!.yymm).toMatch(/^\d{4}$/);
+    });
+
+    it('sn is a 4-char digit string', () => {
+      expect(typeof parsed!.sn).toBe('string');
+      expect(parsed!.sn).toHaveLength(4);
+      expect(parsed!.sn).toMatch(/^\d{4}$/);
+    });
+
+    it('checksum is a single-digit number (0-9)', () => {
+      expect(typeof parsed!.checksum).toBe('number');
+      expect(parsed!.checksum).toBeGreaterThanOrEqual(0);
+      expect(parsed!.checksum).toBeLessThanOrEqual(9);
+      expect(Number.isInteger(parsed!.checksum)).toBe(true);
+    });
+
+    it('does not expose a gender field (CPR format does not encode gender)', () => {
+      expect(parsed).not.toHaveProperty('gender');
+    });
+
+    it('does not expose a birthDate field (CPR carries only YYMM, no day)', () => {
+      expect(parsed).not.toHaveProperty('birthDate');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Extend `src/__tests__/issue-15-bhr-research.test.ts` with a new `describe('issue #17 — additional coverage', …)` block adding 20 new assertions across falsy/non-string inputs, format-boundary cases, structural edge cases, and parse output contract.
- Document why checksum and gender tests are intentionally omitted: the Bahrain CPR checksum algorithm is not publicly documented (see #15 research) and the CPR format \`YYMMSSSSC\` does not encode gender. The omissions are reinforced by negative assertions (\`expect(parsed).not.toHaveProperty('gender'|'birthDate')\`).
- Achieves **100% statements / 100% branches / 100% lines** on \`src/countries/bhr/personal-number.ts\`, above the issue's 90%/85% targets.

Closes #17.

## Scope decisions

| Issue checklist item | Status |
|---|---|
| Valid CPR with correct checksum | Omitted — checksum algorithm unknown (per #15) |
| Multiple valid CPRs (≥5) | Covered (#15 pins 6 format-valid vectors) |
| Edge cases (boundary dates) | New in this PR (year 00/99, month 01/12, serial 0000/9999) |
| Invalid checksum (wrong check digit) | Omitted — algorithm unknown |
| Invalid length (too short/long) | Covered (#15) |
| Invalid characters | Covered (#15) |
| Invalid date components | Covered (#15) — month 00, month 13 |
| Empty string | Covered (#15) |
| Null/undefined handling | **New in this PR** |
| Extract birth date | Partial — only YYMM in CPR (no day) |
| Extract gender | Omitted — CPR does not encode gender |
| Extract sequence number | Covered (#15) |
| Handle parse errors gracefully | Covered (#15) |
| Coverage ≥90% line / ≥85% branch | **Met (100/100)** |

## Test plan

- [x] \`npx jest\` — 1780 tests pass (20 new added in this branch)
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx eslint src/__tests__/issue-15-bhr-research.test.ts\` — clean
- [x] \`npx prettier --check src/__tests__/issue-15-bhr-research.test.ts\` — clean
- [x] \`npx jest --coverage --collectCoverageFrom='src/countries/bhr/**/*.ts'\` — personal-number.ts at 100/100/100/100

## Review history

Reviewer agent ran twice on this branch — round 1 caught two P2 label-accuracy nits (mis-categorised whitespace-padded ID and an inaccurate "serial 1999" label that didn't match the regex parse), round 2 caught a related label inaccuracy on \`'000101000'\` (sn parsed to \`'0100'\`, not \`'0000'\`). All resolved; final re-review APPROVED with no remaining findings.