### PR TITLE
feat(#32): add New Zealand IRD number validation

### DIFF
--- a/src/__tests__/issue-32-nzl-ird.test.ts
+++ b/src/__tests__/issue-32-nzl-ird.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Comprehensive test cases for New Zealand Inland Revenue Department (IRD)
+ * number validation.
+ *
+ * IRD is a SECONDARY NZL id type (accessed via `NZL.IRDNumber`); the registered
+ * NZL primary remains DriverLicense. Valid/invalid fixtures are taken from the
+ * Python source-of-truth tests (`tests/nationalid/test_NZL.py`,
+ * `TestNZLIRDValidation`) plus algorithm-derived edge fixtures for full branch
+ * coverage of the two-phase mod-11 checksum.
+ *
+ * Issue: https://github.com/identique/idnumbers-npm/issues/32
+ */
+
+import { validateNationalId, getCountryIdFormat, NZL } from '../index';
+import { IRDNumber } from '../countries/nzl';
+
+describe('New Zealand (NZL) - IRD Number', () => {
+  describe('METADATA', () => {
+    test('has expected NZ flags and lengths', () => {
+      expect(IRDNumber.METADATA.iso3166Alpha2).toBe('NZ');
+      expect(IRDNumber.METADATA.minLength).toBe(8);
+      expect(IRDNumber.METADATA.maxLength).toBe(9);
+      expect(IRDNumber.METADATA.parsable).toBe(false);
+      expect(IRDNumber.METADATA.checksum).toBe(true);
+      expect(IRDNumber.METADATA.deprecated).toBe(false);
+      expect(IRDNumber.METADATA.aliasOf).toBeNull();
+      expect(IRDNumber.METADATA.names).toContain('IRD');
+      expect(IRDNumber.METADATA.names).toContain('Inland Revenue Department Number');
+    });
+
+    test('regexp is anchored', () => {
+      expect(IRDNumber.METADATA.regexp.source.startsWith('^')).toBe(true);
+      expect(IRDNumber.METADATA.regexp.source.endsWith('$')).toBe(true);
+    });
+  });
+
+  describe('validate() - valid IRD numbers (Python source-of-truth fixtures)', () => {
+    test.each([
+      { id: '49091850', desc: 'plain 8-digit (phase-1, modulus 0)' },
+      { id: '35901981', desc: 'plain 8-digit (phase-1)' },
+      { id: '136410132', desc: 'plain 9-digit (phase-2)' },
+      { id: '49-091-850', desc: 'dashed 8-digit (XX-XXX-XXX)' },
+      { id: '35-901-981', desc: 'dashed 8-digit (XX-XXX-XXX)' },
+      { id: '136-410-132', desc: 'dashed 9-digit (XXX-XXX-XXX)' },
+    ])('should accept $desc ($id)', ({ id }) => {
+      expect(IRDNumber.validate(id)).toBe(true);
+    });
+  });
+
+  describe('validate() - two-phase checksum branch coverage', () => {
+    test('phase-1 modulus-zero path -> check digit 0 (49091850)', () => {
+      expect(IRDNumber.validate('49091850')).toBe(true);
+    });
+
+    test('phase-1 normal path (35901981)', () => {
+      expect(IRDNumber.validate('35901981')).toBe(true);
+    });
+
+    test('phase-2 valid path: phase-1 yields 10, phase-2 matches (136410132)', () => {
+      expect(IRDNumber.validate('136410132')).toBe(true);
+    });
+
+    test('phase-2 check-digit mismatch (136410133)', () => {
+      expect(IRDNumber.validate('136410133')).toBe(false);
+    });
+
+    test('phase-2 result == 10 -> reject (000010740)', () => {
+      // Source where both phase-1 and phase-2 yield a check digit of 10, so no
+      // valid check digit exists; exercises the `phase2 < 10 ? ... : false` branch.
+      expect(IRDNumber.validate('000010740')).toBe(false);
+    });
+  });
+
+  describe('validate() - invalid IRD numbers', () => {
+    test.each([
+      { id: '49091851', desc: 'wrong check digit (8-digit)' },
+      { id: '35901982', desc: 'wrong check digit (8-digit)' },
+      { id: '136410133', desc: 'wrong check digit (9-digit)' },
+    ])('should reject $desc ($id)', ({ id }) => {
+      expect(IRDNumber.validate(id)).toBe(false);
+    });
+
+    test.each([
+      { id: '49 091 850', sep: 'space' },
+      { id: '35.901.981', sep: 'dot' },
+      { id: '136/410/132', sep: 'slash' },
+    ])('should reject ID with $sep separators ($id)', ({ id }) => {
+      expect(IRDNumber.validate(id)).toBe(false);
+    });
+
+    test.each([
+      { id: '4909185', desc: 'too short (7 digits)' },
+      { id: '1364101320', desc: 'too long (10 digits)' },
+      { id: '4909185A', desc: 'contains a letter' },
+      { id: '', desc: 'empty string' },
+      { id: '490-91-850', desc: 'malformed dash grouping' },
+      { id: '1-36-410-132', desc: 'malformed dash grouping' },
+    ])('should reject $desc ($id)', ({ id }) => {
+      expect(IRDNumber.validate(id)).toBe(false);
+    });
+  });
+
+  describe('checksum()', () => {
+    test.each(['49091850', '136410132', '49091851', '136410133'])(
+      'returns a boolean equal to validate() for %s',
+      id => {
+        const result = IRDNumber.checksum(id);
+        expect(typeof result).toBe('boolean');
+        expect(result).toBe(IRDNumber.validate(id));
+      }
+    );
+
+    test('returns false on regexp no-match', () => {
+      expect(IRDNumber.checksum('abc')).toBe(false);
+    });
+  });
+
+  describe('non-string input (throws, matching Python throw-on-non-string)', () => {
+    test('validate throws on number input', () => {
+      expect(() => IRDNumber.validate(49091850 as unknown as string)).toThrow(
+        'idNumber MUST be string'
+      );
+    });
+
+    test('validate throws on null', () => {
+      expect(() => IRDNumber.validate(null as unknown as string)).toThrow(
+        'idNumber MUST be string'
+      );
+    });
+
+    test('validate throws on undefined', () => {
+      expect(() => IRDNumber.validate(undefined as unknown as string)).toThrow(
+        'idNumber MUST be string'
+      );
+    });
+
+    test('checksum throws on number input', () => {
+      expect(() => IRDNumber.checksum(49091850 as unknown as string)).toThrow(
+        'idNumber MUST be string'
+      );
+    });
+  });
+
+  describe('module / namespace export & primary invariant', () => {
+    test('IRDNumber exposes validate, checksum, METADATA', () => {
+      expect(typeof IRDNumber.validate).toBe('function');
+      expect(typeof IRDNumber.checksum).toBe('function');
+      expect(IRDNumber.METADATA).toBeDefined();
+    });
+
+    test('accessible via public NZL namespace', () => {
+      expect(NZL.IRDNumber.validate('136410132')).toBe(true);
+    });
+
+    test('NZL primary is unchanged (DriverLicense, not IRD)', () => {
+      // DriverLicense primary still works.
+      expect(validateNationalId('NZ', 'AB123456').isValid).toBe(true);
+      // IRD-valid but DriverLicense-invalid values must NOT validate via the
+      // primary dispatcher (proves IRD is secondary, not primary). 8-digit IRD
+      // values overlap with DriverLicense, so we use 9-digit / dashed values.
+      expect(validateNationalId('NZ', '136410132').isValid).toBe(false);
+      expect(validateNationalId('NZ', '49-091-850').isValid).toBe(false);
+    });
+
+    test('getCountryIdFormat(NZ) reflects the primary, not IRD', () => {
+      const fmt = getCountryIdFormat('NZ');
+      expect(fmt).not.toBeNull();
+      // DriverLicense traits (no checksum, not parsable); IRD has checksum:true,
+      // so these prove the secondary export did not become primary.
+      expect(fmt!.hasChecksum).toBe(false);
+      expect(fmt!.isParsable).toBe(false);
+    });
+  });
+});

--- a/src/countries/nzl/index.ts
+++ b/src/countries/nzl/index.ts
@@ -1,2 +1,3 @@
 export { NationalID } from './nationalId';
 export { DriverLicense } from './driverLicense';
+export { IRDNumber } from './irdNumber';

--- a/src/countries/nzl/irdNumber.ts
+++ b/src/countries/nzl/irdNumber.ts
@@ -1,0 +1,96 @@
+/**
+ * New Zealand Inland Revenue Department (IRD) Number
+ *
+ * Faithful port of `idnumbers/nationalid/nzl/inland_revenue_department.py`
+ * (the Python source of truth). IRD is a SECONDARY NZL id type: it is exported
+ * from the NZL module and reachable via `NZL.IRDNumber`, but is NOT registered
+ * as the NZL primary validator. The primary remains `DriverLicense`, matching
+ * Python's `NZL.NationalID = alias_of(DriverLicenseNumber)`. Keeping IRD out of
+ * the registry preserves the exactly-80 primary-key invariant.
+ *
+ * Algorithm (two-phase mod-11), per https://github.com/jarden-digital/nz-ird-validator:
+ *   1. Reject via the regexp first.
+ *   2. Strip dashes; left-pad a leading `0` when the core is 8 digits (-> 9 digits).
+ *   3. Phase 1: weighted mod-11 over the first 8 digits with [3,2,7,6,5,4,3,2].
+ *      The check digit is 0 when the modulus is 0, else 11 - modulus. If the
+ *      check digit is not 10, the number is valid iff it equals the 9th digit.
+ *   4. Phase 2 (only when phase 1 yields 10): weighted mod-11 with
+ *      [7,4,3,2,5,2,7,6]. Valid iff the result is < 10 and equals the 9th digit
+ *      (a result of 10 means no valid check digit exists -> invalid).
+ *
+ * Parity note: `validate()`/`checksum()` throw on non-string input (via the
+ * shared `validateRegexp`, which throws 'idNumber MUST be string'). This
+ * preserves the Python source's throw-on-non-string behavior; non-matching
+ * strings return false. (The thrown message is the shared TS utility's own, not
+ * Python-identical.) This intentionally mirrors the ZWE port (#107) rather than
+ * the return-false guard used by the sibling DriverLicense validator.
+ *
+ * https://www.oecd.org/tax/automatic-exchange/crs-implementation-and-assistance/tax-identification-numbers/New%20Zealand-TIN.pdf
+ */
+
+import { IdMetadata } from '../../types';
+import { validateRegexp, normalize, weightedModulusDigit } from '../../utils';
+
+export const METADATA: IdMetadata = {
+  iso3166Alpha2: 'NZ',
+  minLength: 8,
+  maxLength: 9,
+  parsable: false,
+  checksum: true,
+  regexp: /^(\d{9}|\d{3}-\d{3}-\d{3}|\d{8}|\d{2}-\d{3}-\d{3})$/,
+  aliasOf: null,
+  names: ['Inland Revenue Department Number', 'IRD'],
+  links: [
+    'https://www.oecd.org/tax/automatic-exchange/crs-implementation-and-assistance/tax-identification-numbers/New%20Zealand-TIN.pdf',
+  ],
+  deprecated: false,
+};
+
+const PHASE1_MULTIPLIER = [3, 2, 7, 6, 5, 4, 3, 2];
+const PHASE2_MULTIPLIER = [7, 4, 3, 2, 5, 2, 7, 6];
+
+/**
+ * Weighted mod-11 check digit for a single phase.
+ * Mirrors Python `calc_checkdigit`: 0 when the modulus is 0, else 11 - modulus.
+ */
+function calcCheckDigit(source: number[], multipliers: number[]): number {
+  const modulus = weightedModulusDigit(source, multipliers, 11, true);
+  return modulus === 0 ? 0 : 11 - modulus;
+}
+
+/**
+ * Validate the New Zealand IRD number via its two-phase mod-11 checksum.
+ */
+export function checksum(idNumber: string): boolean {
+  if (!validateRegexp(idNumber, METADATA.regexp)) {
+    return false;
+  }
+  let normalized = normalize(idNumber);
+  if (normalized.length === 8) {
+    normalized = '0' + normalized;
+  }
+  const digits = normalized.split('').map(Number);
+  const source = digits.slice(0, 8);
+  const checkDigit = digits[8];
+
+  const phase1 = calcCheckDigit(source, PHASE1_MULTIPLIER);
+  if (phase1 !== 10) {
+    return phase1 === checkDigit;
+  }
+  const phase2 = calcCheckDigit(source, PHASE2_MULTIPLIER);
+  return phase2 < 10 ? phase2 === checkDigit : false;
+}
+
+/**
+ * Validate the New Zealand IRD number. Validity is fully determined by the
+ * checksum (matching Python, where `validate()` delegates to `checksum()`).
+ */
+export function validate(idNumber: string): boolean {
+  return checksum(idNumber);
+}
+
+export const IRDNumber = {
+  validate,
+  checksum,
+  METADATA,
+};

--- a/src/countries/nzl/irdNumber.ts
+++ b/src/countries/nzl/irdNumber.ts
@@ -65,10 +65,9 @@ export function checksum(idNumber: string): boolean {
   if (!validateRegexp(idNumber, METADATA.regexp)) {
     return false;
   }
-  let normalized = normalize(idNumber);
-  if (normalized.length === 8) {
-    normalized = '0' + normalized;
-  }
+  // The 8-digit short form is left-padded to 9 digits; the 9-digit form is
+  // unchanged (the regexp guarantees the core is either 8 or 9 digits).
+  const normalized = normalize(idNumber).padStart(9, '0');
   const digits = normalized.split('').map(Number);
   const source = digits.slice(0, 8);
   const checkDigit = digits[8];

--- a/src/registry/registerAll.ts
+++ b/src/registry/registerAll.ts
@@ -81,6 +81,7 @@ import { CPFNumber } from '../countries/bra';
 // KAZ: BusinessIDNumber (BIN)
 // KOR: OldResidentRegistration (deprecated)
 // LVA: OldPersonalCode (deprecated)
+// NZL: IRDNumber (Inland Revenue Department — primary stays DriverLicense)
 // VEN: FiscalInformationNumber (RIF)
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements New Zealand **IRD (Inland Revenue Department) number** validation (#32, milestone v1.9.0, parent epic #7) as a **secondary** NZL ID type — a faithful port of the Python source of truth (`idnumbers/nationalid/nzl/inland_revenue_department.py`).

IRD is exported as `NZL.IRDNumber` (mirroring the AUS `TaxFileNumber` pattern). The registered NZL **primary stays `DriverLicense`** (matching Python's `NZL.NationalID = alias_of(DriverLicenseNumber)`), so the hard **80-key registry invariant** and existing `validateNationalId('NZ')` behavior are unchanged. No breaking changes.

### Algorithm note
The issue's algorithm sketch was incomplete (single-phase). The real algorithm is **two-phase mod-11**:
- Phase 1 weights `[3, 2, 7, 6, 5, 4, 3, 2]`
- When Phase 1 yields a check digit of 10, fall through to Phase 2 weights `[7, 4, 3, 2, 5, 2, 7, 6]` (a Phase-2 result of 10 → invalid)

Verified against all 12 Python source-of-truth fixtures plus algorithm-derived edge cases.

## Changes
| File | Change |
|------|--------|
| `src/countries/nzl/irdNumber.ts` | **New** — two-phase mod-11 validator (`METADATA`, `checksum`, `validate`, `IRDNumber`) |
| `src/countries/nzl/index.ts` | Export `IRDNumber` from the NZL barrel |
| `src/registry/registerAll.ts` | Doc comment only — IRD is intentionally **not** registered (80-key invariant preserved) |
| `src/__tests__/issue-32-nzl-ird.test.ts` | **New** — 38 tests |

## Behavior notes
- Accepts plain 8/9-digit and `XX-XXX-XXX` / `XXX-XXX-XXX` dashed formats.
- `validate()`/`checksum()` throw `'idNumber MUST be string'` on non-string input (via the shared `validateRegexp`), preserving the Python source's throw-on-non-string behavior — consistent with the ZWE port (#107). Documented in the file header.

## Test plan
- [x] `npm run build` (tsc) clean
- [x] `npm run format:check` + ESLint clean
- [x] `npx jest` — full suite **1994/1994 passing** (24 suites), incl. the 80-key migration invariant (`parseIdInfo-migration.test.ts`)
- [x] `irdNumber.ts` — **100%** statements / branches / functions / lines (incl. the rare Phase-2 reject branch via `000010740`)

## Review
- Internal reviewer agent: **APPROVED** (0 P0 / 0 P1)
- Two independent fresh-context `/review` runs (manual + multi-perspective + Codex gpt-5.5): **APPROVED** (0 P0 / 0 P1)

Closes #32
