### PR TITLE
feat(#46): complete Nigeria NIN parse() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Nigeria (NGA) NIN `parse()` now returns `{ isValid: true }` for valid NINs (previously `{ checksum: null }`) — the NIN is a randomly-assigned number that encodes no personal data, mirroring the Python source (`parsable: False`); added full validate/parse/checksum and registry-integration test coverage ([#46](https://github.com/identique/idnumbers-npm/issues/46))
+
 ## [1.8.0] - 2026-04-28
 
 ### Added

--- a/src/__tests__/issue-46-nga-nationalId.test.ts
+++ b/src/__tests__/issue-46-nga-nationalId.test.ts
@@ -103,12 +103,12 @@ describe('Nigeria (NGA) — National Identification Number (NIN)', () => {
 
   describe('checksum()', () => {
     it('always returns null (NIN has no documented checksum algorithm)', () => {
-      expect(NationalID.checksum()).toBeNull();
+      expect(NationalID.checksum(VALID_NIN)).toBeNull();
     });
 
     it('delegates from the instance method to the static method', () => {
       const instance = new NationalID();
-      expect(instance.checksum()).toBeNull();
+      expect(instance.checksum(VALID_NIN)).toBeNull();
     });
   });
 

--- a/src/__tests__/issue-46-nga-nationalId.test.ts
+++ b/src/__tests__/issue-46-nga-nationalId.test.ts
@@ -25,7 +25,6 @@ import { NationalID, NationalIdParseResult } from '../countries/nga/nationalId';
 import { validateNationalId, parseIdInfo, getCountryIdFormat } from '../index';
 
 const VALID_NIN = '12345678901';
-const VALID_NIN_2 = '12345678902';
 
 describe('Nigeria (NGA) — National Identification Number (NIN)', () => {
   describe('METADATA', () => {
@@ -48,7 +47,7 @@ describe('Nigeria (NGA) — National Identification Number (NIN)', () => {
   });
 
   describe('validate()', () => {
-    it.each([VALID_NIN, VALID_NIN_2, '00000000000', '99999999999'])(
+    it.each([VALID_NIN, '12345678902', '00000000000', '99999999999'])(
       'accepts a valid 11-digit NIN: %s',
       id => {
         expect(NationalID.validate(id)).toBe(true);

--- a/src/__tests__/issue-46-nga-nationalId.test.ts
+++ b/src/__tests__/issue-46-nga-nationalId.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Issue #46 — Nigeria NationalID (NIN) parse() completion & full coverage.
+ * (parent Epic #12, milestone v1.9.0).
+ *
+ * Scope: finalize an HONEST parse() contract and lock branch coverage >=80%
+ * (target 100%) against regressions.
+ *
+ * TS <-> Python parity note:
+ *   - The Python source `idnumbers/nationalid/nga/national_id.py` sets
+ *     `parsable: False`, `checksum: False`, and provides ONLY validate().
+ *   - The Nigerian NIN is a randomly-assigned 11-digit number issued by the
+ *     NIMC that does NOT encode birth date, gender, or state of origin. There
+ *     are therefore no demographic fields to extract, and `METADATA.parsable`
+ *     stays `false`.
+ *   - The Node port keeps a minimal parse() that returns `{ isValid: true }`
+ *     for valid NINs (null otherwise). This is a deliberate, documented
+ *     compatibility shim: it preserves the public `parseIdInfo()` /
+ *     `extractedInfo` contract asserted by the migration suites WITHOUT
+ *     fabricating fields the NIN does not contain.
+ *
+ * Issue: https://github.com/identique/idnumbers-npm/issues/46
+ */
+
+import { NationalID, NationalIdParseResult } from '../countries/nga/nationalId';
+import { validateNationalId, parseIdInfo, getCountryIdFormat } from '../index';
+
+const VALID_NIN = '12345678901';
+const VALID_NIN_2 = '12345678902';
+
+describe('Nigeria (NGA) — National Identification Number (NIN)', () => {
+  describe('METADATA', () => {
+    it('exposes the expected static metadata', () => {
+      expect(NationalID.METADATA.iso3166Alpha2).toBe('NG');
+      expect(NationalID.METADATA.minLength).toBe(11);
+      expect(NationalID.METADATA.maxLength).toBe(11);
+      // The NIN encodes nothing and has no checksum — these MUST stay false
+      // (matches the Python source of truth).
+      expect(NationalID.METADATA.parsable).toBe(false);
+      expect(NationalID.METADATA.checksum).toBe(false);
+      expect(NationalID.METADATA.deprecated).toBe(false);
+      expect(NationalID.METADATA.names).toEqual(['National Identification Number', 'NIN']);
+    });
+
+    it('exposes the same metadata object via the instance getter', () => {
+      const instance = new NationalID();
+      expect(instance.METADATA).toBe(NationalID.METADATA);
+    });
+  });
+
+  describe('validate()', () => {
+    it.each([VALID_NIN, VALID_NIN_2, '00000000000', '99999999999'])(
+      'accepts a valid 11-digit NIN: %s',
+      id => {
+        expect(NationalID.validate(id)).toBe(true);
+      }
+    );
+
+    it.each([
+      ['too short (10 digits)', '1234567890'],
+      ['too long (12 digits)', '123456789012'],
+      ['contains a letter', '1234567890A'],
+      ['contains a space', '1234567 901'],
+      ['contains punctuation', '12345-67890'],
+      ['empty string', ''],
+    ])('rejects an invalid NIN — %s', (_label, id) => {
+      expect(NationalID.validate(id)).toBe(false);
+    });
+
+    it('returns false (no throw) for non-string input', () => {
+      expect(NationalID.validate(undefined as unknown as string)).toBe(false);
+      expect(NationalID.validate(null as unknown as string)).toBe(false);
+      expect(NationalID.validate(12345678901 as unknown as string)).toBe(false);
+    });
+
+    it('delegates from the instance method to the static method', () => {
+      const instance = new NationalID();
+      expect(instance.validate(VALID_NIN)).toBe(true);
+      expect(instance.validate('not-a-nin')).toBe(false);
+    });
+  });
+
+  describe('parse()', () => {
+    it('returns { isValid: true } for a valid NIN (no fabricated fields)', () => {
+      const result = NationalID.parse(VALID_NIN);
+      expect(result).toStrictEqual<NationalIdParseResult>({ isValid: true });
+    });
+
+    it('returns null for an invalid NIN', () => {
+      expect(NationalID.parse('1234567890')).toBeNull();
+      expect(NationalID.parse('')).toBeNull();
+    });
+
+    it('returns null (no throw) for non-string input', () => {
+      expect(NationalID.parse(undefined as unknown as string)).toBeNull();
+      expect(NationalID.parse(null as unknown as string)).toBeNull();
+    });
+
+    it('delegates from the instance method to the static method', () => {
+      const instance = new NationalID();
+      expect(instance.parse(VALID_NIN)).toStrictEqual({ isValid: true });
+      expect(instance.parse('not-a-nin')).toBeNull();
+    });
+  });
+
+  describe('checksum()', () => {
+    it('always returns null (NIN has no documented checksum algorithm)', () => {
+      expect(NationalID.checksum()).toBeNull();
+    });
+
+    it('delegates from the instance method to the static method', () => {
+      const instance = new NationalID();
+      expect(instance.checksum()).toBeNull();
+    });
+  });
+
+  describe('public API integration (registry)', () => {
+    it('validates via validateNationalId for NGA and the NG/ng alias', () => {
+      expect(validateNationalId('NGA', VALID_NIN).isValid).toBe(true);
+      expect(validateNationalId('NG', VALID_NIN).isValid).toBe(true);
+      expect(validateNationalId('ng', VALID_NIN).isValid).toBe(true);
+      expect(validateNationalId('NGA', '1234567890').isValid).toBe(false);
+    });
+
+    it('returns non-null extractedInfo for a valid NIN', () => {
+      const result = validateNationalId('NGA', VALID_NIN);
+      expect(result.extractedInfo).toStrictEqual({ isValid: true });
+    });
+
+    it('returns null extractedInfo for an invalid NIN', () => {
+      expect(validateNationalId('NGA', 'INVALID').extractedInfo).toBeNull();
+    });
+
+    it('parseIdInfo returns { isValid: true } and is alias/case stable', () => {
+      const viaAlpha3 = parseIdInfo('NGA', VALID_NIN);
+      expect(viaAlpha3).toStrictEqual({ isValid: true });
+      expect(parseIdInfo('NG', VALID_NIN)).toStrictEqual(viaAlpha3);
+      expect(parseIdInfo('ng', VALID_NIN)).toStrictEqual(viaAlpha3);
+    });
+
+    it('parseIdInfo returns null for an invalid NIN', () => {
+      expect(parseIdInfo('NGA', 'INVALID')).toBeNull();
+    });
+
+    it('reports a non-parsable, non-checksum format via getCountryIdFormat', () => {
+      const format = getCountryIdFormat('NGA');
+      expect(format).not.toBeNull();
+      expect(format?.countryCode).toBe('NGA');
+      // Derived from METADATA — the NIN is neither parsable nor checksummed.
+      expect(format?.isParsable).toBe(false);
+      expect(format?.hasChecksum).toBe(false);
+      expect(format?.length).toEqual({ min: 11, max: 11 });
+    });
+  });
+});

--- a/src/countries/nga/index.ts
+++ b/src/countries/nga/index.ts
@@ -1,1 +1,1 @@
-export { NationalID } from './nationalId';
+export { NationalID, type NationalIdParseResult } from './nationalId';

--- a/src/countries/nga/nationalId.ts
+++ b/src/countries/nga/nationalId.ts
@@ -91,12 +91,16 @@ export class NationalID implements IdNumberClass {
    * Nigeria NIN doesn't have a publicly documented checksum algorithm, so this
    * always returns `null` (mirrors `checksum: false` in METADATA and the Python
    * source).
+   *
+   * The `idNumber` parameter is unused but retained for signature parity with
+   * the other country modules and the `IdNumberClass` interface.
    */
-  static checksum(): CheckDigit | null {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- retained for signature parity (see JSDoc)
+  static checksum(idNumber: string): CheckDigit | null {
     return null;
   }
 
-  checksum(): CheckDigit | null {
-    return NationalID.checksum();
+  checksum(idNumber: string): CheckDigit | null {
+    return NationalID.checksum(idNumber);
   }
 }

--- a/src/countries/nga/nationalId.ts
+++ b/src/countries/nga/nationalId.ts
@@ -1,12 +1,21 @@
-import { CheckDigit, Gender, Citizenship } from '../../constants';
-import { IdMetadata, IdNumberClass } from '../../types';
+import { CheckDigit } from '../../constants';
+import { IdMetadata, IdNumberClass, ParsedInfo } from '../../types';
 
 /**
- * Parse result of Nigeria national ID
+ * Parse result of Nigeria National Identification Number (NIN).
+ *
+ * The NIN is a randomly-assigned 11-digit number issued by the NIMC. It does
+ * NOT encode any personal information — there is no birth date, gender, or
+ * state of origin embedded in it. Parsing therefore only confirms that the
+ * number is structurally valid; there are no demographic fields to extract.
+ *
+ * This mirrors the Python source of truth
+ * (`idnumbers/nationalid/nga/national_id.py`), which sets `parsable: False`
+ * and provides no parse function.
  */
-export interface NationalIdParseResult {
-  /** Check digit */
-  checksum: CheckDigit | null;
+export interface NationalIdParseResult extends ParsedInfo {
+  /** Always `true` — a non-null result is only returned for valid NINs. */
+  isValid: true;
 }
 
 /**
@@ -37,8 +46,10 @@ export class NationalID implements IdNumberClass {
   }
 
   /**
-   * Validate the Nigeria NIN
-   * NIN is 11 digits with no publicly documented checksum algorithm
+   * Validate the Nigeria NIN.
+   *
+   * NIN is 11 digits with no publicly documented checksum algorithm. Non-string
+   * input returns `false` (rather than throwing) for caller safety.
    */
   static validate(idNumber: string): boolean {
     if (typeof idNumber !== 'string') {
@@ -53,18 +64,23 @@ export class NationalID implements IdNumberClass {
   }
 
   /**
-   * Parse Nigeria national ID number
-   * Since NIN doesn't encode personal information in a publicly documented way,
-   * parsing only returns validation status
+   * Parse the Nigeria NIN.
+   *
+   * The NIN encodes no personal information, so a successful parse returns only
+   * `{ isValid: true }`; invalid numbers return `null`.
+   *
+   * Python's source has no parse function (`parsable: False`). This port keeps a
+   * minimal parse() solely to satisfy the registry/migration contract
+   * (`parseIdInfo()` / `extractedInfo` must be non-null for valid IDs) WITHOUT
+   * fabricating birth date / gender / state-of-origin fields that the NIN does
+   * not contain.
    */
   static parse(idNumber: string): NationalIdParseResult | null {
     if (!NationalID.validate(idNumber)) {
       return null;
     }
 
-    return {
-      checksum: null,
-    };
+    return { isValid: true };
   }
 
   parse(idNumber: string): NationalIdParseResult | null {
@@ -72,13 +88,15 @@ export class NationalID implements IdNumberClass {
   }
 
   /**
-   * Nigeria NIN doesn't have a publicly documented checksum algorithm
+   * Nigeria NIN doesn't have a publicly documented checksum algorithm, so this
+   * always returns `null` (mirrors `checksum: false` in METADATA and the Python
+   * source).
    */
-  static checksum(idNumber: string): CheckDigit | null {
+  static checksum(): CheckDigit | null {
     return null;
   }
 
-  checksum(idNumber: string): CheckDigit | null {
-    return NationalID.checksum(idNumber);
+  checksum(): CheckDigit | null {
+    return NationalID.checksum();
   }
 }


### PR DESCRIPTION
## Summary

Completes the Nigeria NIN `parse()` function (issue #46, epic #12, milestone v1.9.0).

**Important context:** the issue's premise — that the NIN "encodes birth date, state of origin" — is a templated placeholder and is factually incorrect. The NIMC-issued Nigerian NIN is a randomly-assigned 11-digit number that encodes **no** personal data, which is why the Python source of truth (`idnumbers/nationalid/nga/national_id.py`) sets `parsable: False` with no parse function.

This PR implements an **honest** `parse()` that returns validity only — it never fabricates demographic fields the NIN does not contain — while preserving the existing `parseIdInfo()` / `extractedInfo` contract that the migration suites assert.

## Changes

- `parse()` now returns `{ isValid: true }` for valid NINs (`null` otherwise), aligned to the `ParsedInfo` shape (previously returned the uninformative placeholder `{ checksum: null }`).
- `NationalIdParseResult` now extends `ParsedInfo`; the result type is exported (matches the `zaf` sibling pattern).
- Expanded JSDoc documenting why the NIN has no extractable fields, citing Python parity.
- Removed dead imports (`Gender`, `Citizenship`).
- `checksum()` keeps its `idNumber` parameter for signature parity with the other country modules and the `IdNumberClass` interface (the NIN has no checksum, so it always returns `null`).

## Testing

- New `src/__tests__/issue-46-nga-nationalId.test.ts` — 26 tests covering METADATA, `validate()`, `parse()`, `checksum()`, and full registry integration (incl. `NG`/`ng` alias + case stability).
- **nga module: 100% branch / statement / function / line coverage** (up from 50% branch; acceptance criterion was 80%+).
- Full suite: **2020 tests pass**, no regressions. TSC, ESLint, Prettier all clean.

## Acceptance criteria

- [x] `parse()` fully implemented (honest validity-only contract)
- [x] Branch coverage 80%+ (achieved 100%)
- [x] All fields documented (documented that the NIN encodes none, with Python-parity rationale)

Closes #46
