### PR TITLE
refactor(#82): move FORMAT_STRINGS into country METADATA as displayFormat

### DIFF
--- a/src/__tests__/registry.test.ts
+++ b/src/__tests__/registry.test.ts
@@ -1,4 +1,5 @@
 import { ValidatorRegistry, registry } from '../registry';
+import { adaptMetadata } from '../registry/adapters';
 import type { CountryValidator } from '../registry';
 import type { IdMetadata } from '../types';
 
@@ -17,6 +18,7 @@ function createMockValidator(overrides: Partial<IdMetadata> = {}): CountryValida
     names: overrides.names ?? ['Mock ID'],
     links: overrides.links ?? [],
     deprecated: overrides.deprecated ?? false,
+    ...(overrides.displayFormat !== undefined && { displayFormat: overrides.displayFormat }),
   };
 
   return {
@@ -268,6 +270,15 @@ describe('ValidatorRegistry', () => {
       expect(format).toBeDefined();
       expect(format!.format).toBeUndefined();
     });
+
+    it('should include format field when METADATA.displayFormat is set', () => {
+      const v = createMockValidator({ displayFormat: 'YYMMDD-GSSSSSS' });
+      reg.register('KOR', v);
+
+      const format = reg.getFormat('KOR');
+      expect(format).toBeDefined();
+      expect(format!.format).toBe('YYMMDD-GSSSSSS');
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -385,5 +396,20 @@ describe('ValidatorRegistry', () => {
       const { registry: registry2 } = require('../registry');
       expect(registry2).toBe(registry);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// adaptMetadata() — displayFormat propagation through the function-based branch
+// ---------------------------------------------------------------------------
+describe('adaptMetadata()', () => {
+  it('propagates displayFormat from function-based metadata', () => {
+    const meta = adaptMetadata({ pattern: /^\d+$/, displayFormat: 'DDMMYYPPPPSSSS' });
+    expect(meta.displayFormat).toBe('DDMMYYPPPPSSSS');
+  });
+
+  it('leaves displayFormat undefined when function-based metadata omits it', () => {
+    const meta = adaptMetadata({ pattern: /^\d+$/ });
+    expect(meta.displayFormat).toBeUndefined();
   });
 });

--- a/src/countries/idn/index.ts
+++ b/src/countries/idn/index.ts
@@ -26,6 +26,7 @@ export const METADATA = {
   minLength: 16,
   maxLength: 16,
   pattern: /^(?<district>\d{6})(?<dd>[0-7]\d)(?<mm>(0[1-9]|1[012]))(?<yy>\d{2})(?!0000)\d{4}$/,
+  displayFormat: 'DDMMYYPPPPSSSS',
   hasChecksum: false,
   isParsable: true,
   links: [

--- a/src/countries/ind/index.ts
+++ b/src/countries/ind/index.ts
@@ -13,6 +13,7 @@ export const METADATA: IdMetadata = {
   parsable: false,
   checksum: true,
   regexp: /^[2-9]\d{3}[\s-]?\d{4}[\s-]?\d{4}$/,
+  displayFormat: 'XXXX XXXX XXXX',
   aliasOf: null,
   names: [
     'National ID Number',

--- a/src/countries/jpn/index.ts
+++ b/src/countries/jpn/index.ts
@@ -13,6 +13,7 @@ export const METADATA: IdMetadata = {
   parsable: false,
   checksum: true,
   regexp: /^\d{12}$/,
+  displayFormat: 'XXXXXXXXXXXX',
   aliasOf: null,
   names: ['National ID Number', 'My Number', 'マイナンバー'],
   links: ['https://en.wikipedia.org/wiki/National_identification_number#Japan'],

--- a/src/countries/kaz/index.ts
+++ b/src/countries/kaz/index.ts
@@ -21,6 +21,7 @@ export const METADATA: IdMetadata = {
   parsable: true,
   checksum: true,
   regexp: /^(?<yy>\d{2})(?<mm>\d{2})(?<dd>\d{2})(?<century>\d)(?<sn>\d{4})(?<checksum>\d)$/,
+  displayFormat: 'YYMMDDCSSSS',
   aliasOf: null,
   names: ['Individual Identification Number', 'ЖСН', 'ZhSN', 'ИИН', 'IIN'],
   links: [

--- a/src/countries/kor/index.ts
+++ b/src/countries/kor/index.ts
@@ -28,6 +28,7 @@ export const METADATA = {
   minLength: 13,
   maxLength: 14,
   pattern: /^(?<yy>\d{2})(?<mm>\d{2})(?<dd>\d{2})-(?<gender>\d)(?<sn>\d{6})$/,
+  displayFormat: 'YYMMDD-GSSSSSS',
   hasChecksum: false,
   isParsable: true,
   links: [

--- a/src/countries/kwt/index.ts
+++ b/src/countries/kwt/index.ts
@@ -19,6 +19,7 @@ export const METADATA: IdMetadata = {
   parsable: true,
   checksum: true,
   regexp: /^(?<century>\d)(?<yy>\d{2})(?<mm>\d{2})(?<dd>\d{2})(?<sn>\d{4})(?<checksum>\d)$/,
+  displayFormat: 'CYYMMDDSSSS',
   aliasOf: null,
   names: [
     'Civil Number',

--- a/src/countries/lka/index.ts
+++ b/src/countries/lka/index.ts
@@ -33,6 +33,7 @@ export const METADATA: IdMetadata = {
   parsable: true,
   checksum: true,
   regexp: NEW_FORMAT,
+  displayFormat: 'YYYYDDDSSSSC',
   aliasOf: null,
   names: ['National ID Number'],
   links: [

--- a/src/countries/mex/index.ts
+++ b/src/countries/mex/index.ts
@@ -29,6 +29,7 @@ export const METADATA = {
   minLength: 18,
   maxLength: 18,
   pattern: /^(?<initial>[A-Z]{4})(?<yy>\d{2})(?<mm>\d{2})(?<dd>\d{2})(?<gender>[HMX])(?<location>[A-Z]{2})(?<consonant>[A-Z]{3})(?<sn>[0-9A-Z])(?<checksum>\d)$/,
+  displayFormat: 'AAAANNNNNNAAAAAANN',
   hasChecksum: true,
   isParsable: true,
   links: [

--- a/src/countries/mys/nationalId.ts
+++ b/src/countries/mys/nationalId.ts
@@ -29,6 +29,7 @@ export class NationalID implements IdNumberClass {
     parsable: true,
     checksum: false,
     regexp: /^(?<yy>\d{2})(?<mm>\d{2})(?<dd>\d{2})-?(?<pb>\d{2})-?(?<sn>\d{4})$/,
+    displayFormat: 'YYMMDD-PB-###G',
     aliasOf: null,
     names: ['National Registration Identity Card Number', 'NRIC'],
     links: [

--- a/src/countries/nga/nationalId.ts
+++ b/src/countries/nga/nationalId.ts
@@ -32,6 +32,7 @@ export class NationalID implements IdNumberClass {
     parsable: false,
     checksum: false,
     regexp: /^\d{11}$/,
+    displayFormat: 'XXXXXXXXXXX',
     aliasOf: null,
     names: ['National Identification Number', 'NIN'],
     links: [

--- a/src/countries/nor/nationalId.ts
+++ b/src/countries/nor/nationalId.ts
@@ -38,6 +38,7 @@ export class NationalID implements IdNumberClass {
     parsable: true,
     checksum: true,
     regexp: /^(?<dd>\d{2})(?<mm>\d{2})(?<yy>\d{2})(?<individual_number>\d{3})(?<checksum>\d{2})$/,
+    displayFormat: 'DDMMYYIIIKK',
     aliasOf: null,
     names: ['National ID Number', 'fødselsnummer', 'birth number', 'riegádannummir'],
     links: [

--- a/src/countries/pak/nationalId.ts
+++ b/src/countries/pak/nationalId.ts
@@ -30,6 +30,7 @@ export class NationalID implements IdNumberClass {
     parsable: true,
     checksum: false,
     regexp: /^(?<location>\d{5})-?(?<sn>\d{7})-?(?<gender>\d)$/,
+    displayFormat: '#####-#######-#',
     aliasOf: null,
     names: ['National ID Card Number', 'CNIC', 'NIC', 'قومی شناختی کارڈ'],
     links: [

--- a/src/countries/srb/nationalId.ts
+++ b/src/countries/srb/nationalId.ts
@@ -12,6 +12,7 @@ export class NationalID implements IdNumberClass {
     parsable: true,
     checksum: true,
     regexp: /^\d{13}$/,
+    displayFormat: 'DDMMYYYRRSSSC',
     aliasOf: null,
     names: ['JMBG', 'Jedinstveni matični broj građana', 'Unique Master Citizen Number'],
     links: [

--- a/src/countries/svn/nationalId.ts
+++ b/src/countries/svn/nationalId.ts
@@ -12,6 +12,7 @@ export class NationalID implements IdNumberClass {
     parsable: true,
     checksum: true,
     regexp: /^\d{13}$/,
+    displayFormat: 'DDMMYYYRRSSSC',
     aliasOf: null,
     names: ['EMŠO', 'Enotna matična številka občana', 'Unique Master Citizen Number'],
     links: [

--- a/src/countries/tha/nationalId.ts
+++ b/src/countries/tha/nationalId.ts
@@ -44,6 +44,7 @@ export class NationalID implements IdNumberClass {
     parsable: true,
     checksum: true,
     regexp: /^(?<citizenship>[0-8])[\s-]?(?<province>\d{2})(?<district>\d{2})[\s-]?(?<sn>\d{5}[\s-]?\d{2})[\s-]?(?<checksum>\d)$/,
+    displayFormat: '#-####-#####-##-#',
     aliasOf: null,
     names: [
       'National ID Number',

--- a/src/countries/twn/nationalId.ts
+++ b/src/countries/twn/nationalId.ts
@@ -33,6 +33,7 @@ export class NationalID implements IdNumberClass {
     parsable: true,
     checksum: true,
     regexp: /^(?<location>[A-Z])(?<gender>[12])(?<sn>\d{7})(?<checksum>\d)$/,
+    displayFormat: 'X#########',
     aliasOf: null,
     names: ['National ID Number', '國民身分證統一編號', '身分證字號'],
     links: [

--- a/src/countries/ven/nationalId.ts
+++ b/src/countries/ven/nationalId.ts
@@ -13,6 +13,7 @@ export class NationalID implements IdNumberClass {
     parsable: true,
     checksum: false,
     regexp: /^[VEJG][\d\.\-\s]{7,}$/,
+    displayFormat: 'V-######## or E-########',
     aliasOf: null,
     names: ['Cédula de Identidad'],
     links: [],

--- a/src/countries/vnm/nationalId.ts
+++ b/src/countries/vnm/nationalId.ts
@@ -36,6 +36,7 @@ export class NationalID implements IdNumberClass {
     parsable: true,
     checksum: false,
     regexp: /^(?:(?<province_country_code>\d{3})(?<gender>\d)(?<yy>\d{2})(?<sn>\d{6})|\d{9})$/,
+    displayFormat: 'Variable (9 or 12 digits)',
     aliasOf: null,
     names: ['National ID Number', 'Thẻ căn cước công dân'],
     links: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -252,34 +252,14 @@ export function listSupportedCountries(): CountryInfo[] {
 }
 
 // ---------------------------------------------------------------------------
-// Format enrichment: countryName, idType from SUPPORTED_COUNTRIES + format
-// display strings preserved from the old switch statement.
+// Format enrichment: overlay countryName + idType from SUPPORTED_COUNTRIES.
+// Format display strings now live in each country's METADATA.displayFormat and
+// are surfaced by registry.getFormat().
 // ---------------------------------------------------------------------------
 const countryInfoMap = new Map<string, { countryName: string; idType: string }>();
 for (const entry of SUPPORTED_COUNTRIES) {
   countryInfoMap.set(entry.code, { countryName: entry.name, idType: entry.idType });
 }
-
-const FORMAT_STRINGS: Record<string, string> = {
-  IND: 'XXXX XXXX XXXX',
-  JPN: 'XXXXXXXXXXXX',
-  KAZ: 'YYMMDDCSSSS',
-  KWT: 'CYYMMDDSSSS',
-  IDN: 'DDMMYYPPPPSSSS',
-  KOR: 'YYMMDD-GSSSSSS',
-  MEX: 'AAAANNNNNNAAAAAANN',
-  LKA: 'YYYYDDDSSSSC',
-  NGA: 'XXXXXXXXXXX',
-  MYS: 'YYMMDD-PB-###G',
-  NOR: 'DDMMYYIIIKK',
-  PAK: '#####-#######-#',
-  THA: '#-####-#####-##-#',
-  VNM: 'Variable (9 or 12 digits)',
-  SVN: 'DDMMYYYRRSSSC',
-  SRB: 'DDMMYYYRRSSSC',
-  TWN: 'X#########',
-  VEN: 'V-######## or E-########',
-};
 
 /**
  * Get information about the ID number format for a specific country.
@@ -295,11 +275,9 @@ export function getCountryIdFormat(countryCode: string): IdFormat | null {
 
   // Build enriched copy instead of mutating the registry object
   const info = countryInfoMap.get(format.countryCode);
-  const formatStr = FORMAT_STRINGS[format.countryCode];
 
   return {
     ...format,
     ...(info && { countryName: info.countryName, idType: info.idType }),
-    ...(formatStr && { format: formatStr }),
   };
 }

--- a/src/registry/ValidatorRegistry.ts
+++ b/src/registry/ValidatorRegistry.ts
@@ -124,6 +124,9 @@ export class ValidatorRegistry implements IValidatorRegistry {
       countryCode,
       countryName,
       idType,
+      // Surface the display format only when present. The `!== undefined` guard
+      // leaves the optional `format` key absent (not set to undefined) for
+      // countries without a displayFormat, matching IdFormat.format?'s contract.
       ...(METADATA.displayFormat !== undefined && { format: METADATA.displayFormat }),
       length: { min: METADATA.minLength, max: METADATA.maxLength },
       hasChecksum: METADATA.checksum,

--- a/src/registry/ValidatorRegistry.ts
+++ b/src/registry/ValidatorRegistry.ts
@@ -124,6 +124,7 @@ export class ValidatorRegistry implements IValidatorRegistry {
       countryCode,
       countryName,
       idType,
+      ...(METADATA.displayFormat !== undefined && { format: METADATA.displayFormat }),
       length: { min: METADATA.minLength, max: METADATA.maxLength },
       hasChecksum: METADATA.checksum,
       isParsable: METADATA.parsable,

--- a/src/registry/adapters.ts
+++ b/src/registry/adapters.ts
@@ -12,6 +12,7 @@ export interface FunctionBasedMetadata {
   isParsable?: boolean;
   hasChecksum?: boolean;
   pattern?: RegExp;
+  displayFormat?: string;
   names?: string[];
   links?: string[];
 }
@@ -54,6 +55,7 @@ export function adaptMetadata(meta: AnyMetadata): IdMetadata {
     parsable: fn.isParsable ?? false,
     checksum: fn.hasChecksum ?? false,
     regexp: fn.pattern ?? /./,
+    displayFormat: fn.displayFormat,
     aliasOf: null,
     names: fn.names ?? [],
     links: fn.links ?? [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,8 @@ export interface IdMetadata {
   checksum: boolean;
   /** Regular expression to validate the ID */
   regexp: RegExp;
+  /** Human-readable display format string (e.g. "YYMMDD-GSSSSSS") */
+  displayFormat?: string;
   /** If this is an alias of another ID type */
   aliasOf: any | null;
   /** Common names for this ID type */


### PR DESCRIPTION
## Summary

Closes #82.

Moves the 18-entry `FORMAT_STRINGS` display-string lookup out of `src/index.ts` and into each country module's `METADATA` as a new optional `displayFormat` field — establishing a single source of truth so format info travels with the validation metadata.

**No behavior change**: `getCountryIdFormat()` output is byte-for-byte identical (verified by the existing parity test in `getCountryIdFormat-migration.test.ts`).

## Changes

- `src/types.ts` — add `displayFormat?: string` to `IdMetadata`
- `src/registry/adapters.ts` — add the field to `FunctionBasedMetadata` and propagate it in `adaptMetadata()`
- `src/registry/ValidatorRegistry.ts` — surface `format` from `METADATA.displayFormat` via a `!== undefined` conditional spread (keeps the optional key absent for countries without a format)
- `src/index.ts` — remove the `FORMAT_STRINGS` constant and its overlay from `getCountryIdFormat()`
- 18 country modules — add `displayFormat` to each `METADATA` (values copied verbatim)
- `src/__tests__/registry.test.ts` — 3 reinforcing tests (getFormat positive case + adaptMetadata both branches) and mock-helper passthrough

### How both METADATA shapes are handled

- **Class-based (15 countries)** — `adaptMetadata()` returns the object by reference, so `displayFormat` propagates automatically.
- **Function-based (IDN/KOR/MEX)** — `adaptMetadata()` rebuilds the object, so it explicitly copies `displayFormat`.

## Validation

- `npm run build` (tsc) — pass
- `npm test` — 2023/2023 passing (25 suites)
- `npm run format:check` — pass
- `npm run lint` — pass
- `grep FORMAT_STRINGS src/` — removed
- Registry invariant preserved: `registry.list().length === 80`

## Breaking changes

None. `registry.getFormat()` additionally surfaces `format` for the 18 countries — additive and non-breaking.
