### PR TITLE
chore(release): bump version to 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-07-17
+
 ### Added
 
 - Format information for all 40 European countries via `getCountryIdFormat()` — each now returns a `format` display mask, a valid `example`, a `checksumAlgorithm` description, and the `officialName` (local name) ([#42](https://github.com/identique/idnumbers-npm/issues/42))
 - `IdMetadata` and `IdFormat` gain optional `example`, `checksumAlgorithm`, and `officialName` fields, populated from each country's METADATA ([#42](https://github.com/identique/idnumbers-npm/issues/42))
 - Format information for all 26 Asian countries via `getCountryIdFormat()` — `format` display mask, valid `example`, `checksumAlgorithm` description, and `officialName` (local name) ([#43](https://github.com/identique/idnumbers-npm/issues/43))
+- Format information for the Americas, Africa, and Oceania countries via `getCountryIdFormat()`, completing `format`, `example`, `checksumAlgorithm`, and `officialName` coverage across all 80 registered countries ([#44](https://github.com/identique/idnumbers-npm/issues/44))
+- New Zealand (NZL) IRD number validation as a secondary `NZL.IRDNumber` id type — two-phase mod-11 checksum, accepting 8/9-digit plain and `XX-XXX-XXX` / `XXX-XXX-XXX` dashed formats. The registered NZL primary remains the Driver Licence, so `validateNationalId('NZ')` behavior is unchanged ([#32](https://github.com/identique/idnumbers-npm/issues/32))
+- Per-country README for Zimbabwe (ZWE) documenting the format, the mod-23 checksum algorithm with its 23-letter table, the 61 valid district/register-office codes, and verified test vectors ([#25](https://github.com/identique/idnumbers-npm/issues/25))
+- Comprehensive Zimbabwe (ZWE) NationalID test coverage — all 61 valid district codes, all 23 checksum residues, 11- and 12-digit parse shapes, instance/static delegation, and registry integration through the `ZWE`, `ZW`, and lowercase `zw` aliases ([#26](https://github.com/identique/idnumbers-npm/issues/26))
+- Bahrain (BHR) CPR checksum research record, documenting that the official check-digit algorithm is not publicly available; validation remains format-only with `METADATA.checksum = false`, in parity with the Python source ([#15](https://github.com/identique/idnumbers-npm/issues/15))
+- Expanded Bahrain (BHR) coverage — falsy and non-string inputs, boundary conditions, and parse-contract assertions at both the module and registry layers ([#17](https://github.com/identique/idnumbers-npm/issues/17))
 
 ### Changed
 
 - Portugal (PRT) `idType` corrected from "Citizen Card" to "Tax Identification Number (NIF)" to match the registered NIF validator ([#42](https://github.com/identique/idnumbers-npm/issues/42))
 - Nigeria (NGA) NIN `parse()` now returns `{ isValid: true }` for valid NINs (previously `{ checksum: null }`) — the NIN is a randomly-assigned number that encodes no personal data, mirroring the Python source (`parsable: False`); added full validate/parse/checksum and registry-integration test coverage ([#46](https://github.com/identique/idnumbers-npm/issues/46))
+- Format display strings moved from the centralized `FORMAT_STRINGS` lookup in `src/index.ts` into each country's METADATA as a new optional `displayFormat` field, so format information lives alongside the validation metadata it describes. `getCountryIdFormat()` surfaces it via `ValidatorRegistry.getFormat()`, and countries without a display string continue to report `format === undefined`. `FORMAT_STRINGS` was module-private, so this is not a breaking change ([#82](https://github.com/identique/idnumbers-npm/issues/82))
 
 ### Fixed
 
 - Corrected inaccurate `displayFormat` masks for Indonesia (IDN), Kazakhstan (KAZ), Kuwait (KWT), and Vietnam (VNM); Bangladesh (BGD) now reports the full accepted length range `{ min: 13, max: 17 }` covering both old and new national ID formats ([#43](https://github.com/identique/idnumbers-npm/issues/43))
+- New Zealand (NZL) `idType` corrected from "IRD Number" to "Driver Licence Number". `getCountryIdFormat('NZL')` previously returned a self-contradictory object, overlaying the IRD `idType` on the Driver Licence `format`, `example`, and `officialName` of the registered primary validator ([#44](https://github.com/identique/idnumbers-npm/issues/44))
 
 ## [1.8.0] - 2026-04-28
 
@@ -163,7 +173,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions
 - Comprehensive documentation and examples
 
-[Unreleased]: https://github.com/identique/idnumbers-npm/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/identique/idnumbers-npm/compare/v1.9.0...HEAD
+[1.9.0]: https://github.com/identique/idnumbers-npm/compare/v1.8.0...v1.9.0
+[1.8.0]: https://github.com/identique/idnumbers-npm/compare/v1.7.0...v1.8.0
+[1.7.0]: https://github.com/identique/idnumbers-npm/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/identique/idnumbers-npm/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/identique/idnumbers-npm/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/identique/idnumbers-npm/compare/v1.4.0...v1.4.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idnumbers",
-  "version": "1.7.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "idnumbers",
-      "version": "1.7.0",
+      "version": "1.9.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idnumbers",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "A TypeScript library for verifying and parsing national ID numbers - supports 80 countries across 6 continents including USA, UK, France, Germany, Japan, China, India, Brazil, and many more",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release prep for v1.9.0, mirroring the v1.8.0 flow (#103). No code changes — only release bookkeeping.

## Contents

All 24 commits on `main` since v1.8.0, reconciled into the changelog:

- **Added** — format info completing all 80 countries (#42 Europe, #43 Asia, #44 Americas/Africa/Oceania); NZ IRD number validation as secondary `NZL.IRDNumber` (#32); Zimbabwe per-country README (#25) and full test coverage (#26); Bahrain CPR research record (#15) and expanded coverage (#17)
- **Changed** — Portugal `idType` (#42); Nigeria NIN `parse()` (#46); `FORMAT_STRINGS` → `METADATA.displayFormat` (#82)
- **Fixed** — inaccurate display masks for IDN/KAZ/KWT/VNM + BGD length range (#43); NZL `idType` corrected to Driver Licence Number (#44)

No new countries — the registry stays at **80 primary keys**, so the README count and `parseIdInfo-migration` invariant are unchanged.

## Version

Minor bump. #82 removed `FORMAT_STRINGS`, but it was a module-private `const` and never exported, so there is no breaking change to the public API.

## Two drift fixes bundled in (please sanity-check)

1. **`package-lock.json` was stranded at 1.7.0** — no release commit has ever bumped it. `npm ci` only validates dependency sync, not the root version, which is why publishes kept succeeding. Bumped to 1.9.0 alongside `package.json` via `npm version --no-git-tag-version`; the lock diff is the two version fields only, no dependency churn.
2. **Changelog compare-links stopped at 1.6.0** — the 1.7.0 and 1.8.0 releases never added theirs, and `[Unreleased]` still pointed at `v1.6.0...HEAD`. Added `[1.9.0]` and backfilled the two missing lines.

## Verification

Full CI gauntlet green locally, before and after: Prettier ✅ · ESLint ✅ · `tsc` build ✅ · **2139 tests / 28 suites passing** ✅ (test count already matches the README).

## After merge

Tag and release stay manual, as with v1.8.0:

```
git tag -a v1.9.0 -m "Release v1.9.0"   # on the merge commit
git push origin v1.9.0
```

Then publish a GitHub release titled `v1.9.0` with the changelog section as the body — that fires `npm-publish.yml` and pushes to npm.
