### PR TITLE
feat(#56): add Costa Rica cédula validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Costa Rica (CRI) Cédula de Identidad validator — validates the 9-digit national ID (`P-TTTT-AAAA`: province 1-9, tomo, asiento); notably has no check digit, since Costa Rica confirms validity via Registro Civil / TRIBU-CR database lookup rather than arithmetic ([#56](https://github.com/identique/idnumbers-npm/issues/56))
 - Format information for all 40 European countries via `getCountryIdFormat()` — each now returns a `format` display mask, a valid `example`, a `checksumAlgorithm` description, and the `officialName` (local name) ([#42](https://github.com/identique/idnumbers-npm/issues/42))
 - `IdMetadata` and `IdFormat` gain optional `example`, `checksumAlgorithm`, and `officialName` fields, populated from each country's METADATA ([#42](https://github.com/identique/idnumbers-npm/issues/42))
 - Format information for all 26 Asian countries via `getCountryIdFormat()` — `format` display mask, valid `example`, `checksumAlgorithm` description, and `officialName` (local name) ([#43](https://github.com/identique/idnumbers-npm/issues/43))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # idnumbers
 
-A comprehensive TypeScript/JavaScript library for validating and parsing national identification numbers from 80 countries across 6 continents.
+A comprehensive TypeScript/JavaScript library for validating and parsing national identification numbers from 81 countries across 6 continents.
 
 [![npm version](https://img.shields.io/npm/v/idnumbers.svg)](https://www.npmjs.com/package/idnumbers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -8,7 +8,7 @@ A comprehensive TypeScript/JavaScript library for validating and parsing nationa
 
 ## Features
 
-- ✅ **80 countries supported** - Comprehensive coverage across all continents
+- ✅ **81 countries supported** - Comprehensive coverage across all continents
 - 🔍 **Validation** - Verify ID number format and checksums
 - 📊 **Parsing** - Extract information like birth date, gender, and citizenship
 - 🛡️ **Type-safe** - Full TypeScript support with type definitions
@@ -195,11 +195,12 @@ console.log(format);
 
 ## Supported Countries
 
-### North America (3)
+### North America (4)
 
 - 🇺🇸 **USA** - Social Security Number (SSN)
 - 🇨🇦 **CAN** - Social Insurance Number (SIN)
 - 🇲🇽 **MEX** - CURP (Clave Única de Registro de Población)
+- 🇨🇷 **CRI** - Cédula de Identidad
 
 ### South America (5)
 
@@ -473,7 +474,7 @@ if (!validation.valid) {
 
 ## Testing
 
-The library includes comprehensive test coverage with 2139 tests covering:
+The library includes comprehensive test coverage with 2174 tests covering:
 
 - Format validation
 - Checksum verification

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "idnumbers",
   "version": "1.8.0",
-  "description": "A TypeScript library for verifying and parsing national ID numbers - supports 80 countries across 6 continents including USA, UK, France, Germany, Japan, China, India, Brazil, and many more",
+  "description": "A TypeScript library for verifying and parsing national ID numbers - supports 81 countries across 6 continents including USA, UK, France, Germany, Japan, China, India, Brazil, and many more",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/src/__tests__/getCountryIdFormat-migration.test.ts
+++ b/src/__tests__/getCountryIdFormat-migration.test.ts
@@ -2,13 +2,13 @@
  * Parity tests for getCountryIdFormat registry migration (Issue #53).
  *
  * Verifies that the registry-based getCountryIdFormat returns complete
- * IdFormat info for all 80 registered countries, preserves format strings,
+ * IdFormat info for all 81 registered countries, preserves format strings,
  * resolves aliases, and returns null for unregistered codes.
  */
 import { getCountryIdFormat, SUPPORTED_COUNTRIES } from '../index';
 
 // ---------------------------------------------------------------------------
-// All 80 registered countries should return non-null IdFormat
+// All 81 registered countries should return non-null IdFormat
 // ---------------------------------------------------------------------------
 describe('getCountryIdFormat returns IdFormat for all registered countries', () => {
   const registeredCountries = [
@@ -92,6 +92,7 @@ describe('getCountryIdFormat returns IdFormat for all registered countries', () 
     { code: 'NPL', name: 'Nepal', idType: 'National ID Number' },
     { code: 'PNG', name: 'Papua New Guinea', idType: 'National ID Number' },
     { code: 'SMR', name: 'San Marino', idType: 'Social Security Number / Tax Registration' },
+    { code: 'CRI', name: 'Costa Rica', idType: 'Cédula de Identidad' },
   ];
 
   test.each(registeredCountries)(
@@ -123,6 +124,7 @@ describe('Format display strings', () => {
     { code: 'CAN', format: '###-###-###' },
     { code: 'CHL', format: '##.###.###-C' },
     { code: 'COL', format: '##(#).###.###-C' },
+    { code: 'CRI', format: '#-####-####' },
     { code: 'IND', format: 'XXXX XXXX XXXX' },
     { code: 'JPN', format: 'XXXXXXXXXXXX' },
     { code: 'KAZ', format: 'YYMMDDGSSSSC' },
@@ -233,7 +235,6 @@ describe('Edge cases and unregistered codes', () => {
     'EC',
     'BO',
     'PY',
-    'CR',
     'PA',
     'DO',
     'GT',

--- a/src/__tests__/issue-56-cri.test.ts
+++ b/src/__tests__/issue-56-cri.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Costa Rica Cédula de Identidad validator tests (Issue #56).
+ *
+ * Verified fixtures: the cédula física has NO check digit -- Costa Rica
+ * validates it via Registro Civil / TRIBU-CR database lookup, not arithmetic.
+ * The province-0 and jurídica/DIMEX rejections below are regression guards
+ * against copying python-stdnum's wrong 10-digit (0P-TTTT-AAAA) model, which
+ * conflates Hacienda's "naturaleza" prefix with the province digit.
+ */
+import { Cedula } from '../countries/cri';
+import { validateNationalId, parseIdInfo, getCountryIdFormat } from '../index';
+
+describe('Costa Rica Cédula de Identidad', () => {
+  describe('valid IDs', () => {
+    const validIds = [
+      '1-0913-0259', // Hacienda's own published example
+      '109130259',
+      '3-0455-0175',
+      '701610395',
+      '8-0123-0456', // province 8 (naturalized)
+      '9-0123-0456', // province 9 (Partida Especial)
+    ];
+
+    test.each(validIds)('validates %s', id => {
+      expect(Cedula.validate(id)).toBe(true);
+    });
+  });
+
+  describe('invalid IDs', () => {
+    const invalidCases: Array<[string, string]> = [
+      ['009130259', 'province 0 (naturaleza prefix, not a valid province)'],
+      ['10913025', '8 digits (too short)'],
+      ['1091302599', '10 digits (too long / cédula jurídica length)'],
+      ['3101123456', 'cédula jurídica (10 digits, starts 2-5)'],
+      // DIMEX numbers commonly start with '1', same as a San José cédula. These
+      // two are the regression guard for the closing `$` anchor: without it,
+      // `/^[1-9]\d{8}/` would match the leading 9 digits of a longer DIMEX
+      // string and wrongly accept it.
+      ['155812345678', 'DIMEX (12 digits)'],
+      ['12345678901', 'DIMEX (11 digits)'],
+      ['10913025A', 'non-digit character'],
+      ['', 'empty string'],
+      // DECISION regression guard: we do NOT re-pad under-length, un-hyphenated
+      // input. "1613584" could mean a missing tomo zero (1-0613-584, invalid --
+      // still only 8 sig. digits) or a missing asiento zero -- it can't be
+      // segmented unambiguously, so it must be rejected rather than guessed at.
+      ['1613584', 'un-padded 7-digit form (ambiguous, not re-padded)'],
+    ];
+
+    test.each(invalidCases)('rejects %s (%s)', id => {
+      expect(Cedula.validate(id)).toBe(false);
+    });
+
+    it('rejects non-string input', () => {
+      expect(Cedula.validate(null as unknown as string)).toBe(false);
+      expect(Cedula.validate(undefined as unknown as string)).toBe(false);
+      expect(Cedula.validate(109130259 as unknown as string)).toBe(false);
+    });
+
+    it('does not match a DIMEX number via an unanchored prefix (end anchor regression)', () => {
+      // Sanity-check the trap itself: the first 9 characters of this DIMEX
+      // number alone WOULD satisfy `[1-9]\d{8}` -- proving the `$` anchor,
+      // not the length check alone, is what rejects the full string.
+      const dimex = '155812345678';
+      expect(/^[1-9]\d{8}/.test(dimex)).toBe(true);
+      expect(Cedula.validate(dimex)).toBe(false);
+    });
+  });
+
+  describe('parse', () => {
+    it('extracts province, tomo, and asiento from a dashed ID', () => {
+      const result = Cedula.parse('1-0913-0259');
+      expect(result).toEqual({
+        province: 1,
+        provinceName: 'San José',
+        tomo: '0913',
+        asiento: '0259',
+      });
+    });
+
+    it('extracts the same fields from the undashed form', () => {
+      expect(Cedula.parse('109130259')).toEqual(Cedula.parse('1-0913-0259'));
+    });
+
+    it('labels province 8 as naturalized citizen', () => {
+      const result = Cedula.parse('8-0123-0456');
+      expect(result?.province).toBe(8);
+      expect(result?.provinceName).toBe('Naturalized citizen');
+    });
+
+    it('labels province 9 as Partida Especial', () => {
+      const result = Cedula.parse('9-0123-0456');
+      expect(result?.province).toBe(9);
+      expect(result?.provinceName).toContain('Partida Especial');
+    });
+
+    it('returns null for invalid IDs', () => {
+      expect(Cedula.parse('009130259')).toBeNull();
+      expect(Cedula.parse('3101123456')).toBeNull();
+      expect(Cedula.parse('')).toBeNull();
+    });
+  });
+
+  describe('instance methods', () => {
+    it('validate() and parse() delegate to the static implementation', () => {
+      const cedula = new Cedula();
+      expect(cedula.validate('1-0913-0259')).toBe(true);
+      expect(cedula.parse('1-0913-0259')).toEqual(Cedula.parse('1-0913-0259'));
+    });
+  });
+
+  describe('METADATA', () => {
+    it('has no checksum and is parsable', () => {
+      expect(Cedula.METADATA.checksum).toBe(false);
+      expect(Cedula.METADATA.parsable).toBe(true);
+    });
+
+    it('example passes validateNationalId', () => {
+      const result = validateNationalId('CRI', Cedula.METADATA.example!);
+      expect(result.isValid).toBe(true);
+    });
+  });
+
+  describe('registry integration', () => {
+    it('validates via validateNationalId with alpha-3 code', () => {
+      const result = validateNationalId('CRI', '1-0913-0259');
+      expect(result.isValid).toBe(true);
+      expect(result.countryCode).toBe('CRI');
+    });
+
+    it('validates via validateNationalId with alpha-2 alias', () => {
+      const result = validateNationalId('CR', '1-0913-0259');
+      expect(result.isValid).toBe(true);
+      expect(result.countryCode).toBe('CRI');
+    });
+
+    it('rejects province 0 via validateNationalId', () => {
+      const result = validateNationalId('CRI', '009130259');
+      expect(result.isValid).toBe(false);
+    });
+
+    it('parses via parseIdInfo', () => {
+      const info = parseIdInfo('CRI', '1-0913-0259');
+      expect(info).not.toBeNull();
+      expect(info).toMatchObject({ province: 1, tomo: '0913', asiento: '0259' });
+    });
+
+    it('returns null via parseIdInfo for invalid input', () => {
+      expect(parseIdInfo('CRI', '3101123456')).toBeNull();
+    });
+
+    it('exposes format info via getCountryIdFormat', () => {
+      const format = getCountryIdFormat('CRI');
+      expect(format).not.toBeNull();
+      expect(format!.countryCode).toBe('CRI');
+      expect(format!.countryName).toBe('Costa Rica');
+      expect(format!.idType).toBe('Cédula de Identidad');
+      expect(format!.hasChecksum).toBe(false);
+      expect(format!.isParsable).toBe(true);
+      expect(format!.length).toEqual({ min: 9, max: 9 });
+    });
+  });
+});

--- a/src/__tests__/parseIdInfo-migration.test.ts
+++ b/src/__tests__/parseIdInfo-migration.test.ts
@@ -12,8 +12,8 @@ import { adaptMetadata, createValidator } from '../registry/adapters';
 // Registry population tests
 // ---------------------------------------------------------------------------
 describe('Registry population', () => {
-  it('should have 80 primary keys registered', () => {
-    expect(registry.list().length).toBe(80);
+  it('should have 81 primary keys registered', () => {
+    expect(registry.list().length).toBe(81);
   });
 
   it('should resolve all expected alpha-3 keys', () => {
@@ -98,6 +98,7 @@ describe('Registry population', () => {
       'SRB',
       'TWN',
       'VEN',
+      'CRI',
     ];
 
     for (const key of expectedKeys) {
@@ -180,6 +181,7 @@ describe('Registry population', () => {
       PT: 'PRT',
       SA: 'SAU',
       TR: 'TUR',
+      CR: 'CRI',
     };
 
     for (const [alias, primaryKey] of Object.entries(expectedAliases)) {
@@ -383,6 +385,12 @@ describe('parseIdInfo parity (registry vs old switch)', () => {
     { code: 'IRL', alias: 'IE', validId: '1234567T', description: 'Ireland PPS' },
     { code: 'LVA', alias: 'LV', validId: '161175-19997', description: 'Latvia Personal Code' },
     { code: 'LKA', alias: 'LK', validId: '199001200001', description: 'Sri Lanka NIC' },
+    {
+      code: 'CRI',
+      alias: 'CR',
+      validId: '1-0913-0259',
+      description: 'Costa Rica Cédula de Identidad',
+    },
   ];
 
   describe.each(parseableCountries)('$description ($code)', ({ code, alias, validId }) => {

--- a/src/countries/cri/cedula.ts
+++ b/src/countries/cri/cedula.ts
@@ -1,0 +1,124 @@
+/**
+ * Costa Rica Cédula de Identidad
+ * (National identity card number for Costa Rican citizens)
+ */
+
+import { IdNumberClass, IdMetadata } from '../../types';
+import { normalize } from '../../utils';
+
+export interface CedulaParseResult {
+  /** Province digit (1-9); see PROVINCE_NAMES for what each value represents */
+  province: number;
+  /** Human-readable meaning of the province digit */
+  provinceName: string;
+  /** "Tomo" (book) number -- 4 digits, zero-padded */
+  tomo: string;
+  /** "Asiento" (entry) number -- 4 digits, zero-padded */
+  asiento: string;
+}
+
+/**
+ * Meaning of the leading province digit. 1-7 are Costa Rica's seven
+ * geographic provinces; 8 and 9 are special issuance categories rather
+ * than provinces.
+ */
+const PROVINCE_NAMES: Record<number, string> = {
+  1: 'San José',
+  2: 'Alajuela',
+  3: 'Cartago',
+  4: 'Heredia',
+  5: 'Guanacaste',
+  6: 'Puntarenas',
+  7: 'Limón',
+  8: 'Naturalized citizen',
+  9: 'Partida Especial (late registration / born abroad)',
+};
+
+export class Cedula implements IdNumberClass {
+  static readonly METADATA: IdMetadata = {
+    iso3166Alpha2: 'CR',
+    minLength: 9,
+    maxLength: 9,
+    parsable: true,
+    checksum: false,
+    // Province digit is 1-9; a leading 0 is invalid (see NOTE below on why 0
+    // must stay rejected).
+    //
+    // The trailing `$` is load-bearing, not decorative: DIMEX numbers (11-12
+    // digits) commonly start with '1', same as a San José cédula. Without the
+    // end anchor, `/^[1-9]\d{8}/` would match the first 9 digits of a longer
+    // DIMEX string and wrongly accept it as a cédula física. Do not drop it,
+    // and do not swap this for a normalize()-then-cleanDigits() flow that
+    // only checks a length range -- the anchors are what make length exact.
+    //
+    // DECISION: we deliberately do NOT re-pad under-length input. Some sources
+    // (python-stdnum's docstring) note people write cédulas with the
+    // intra-group zeros omitted, e.g. "1-613-584" for "1-0913-0584" -- sic,
+    // this is a documentation example of the omission pattern, not a real ID.
+    // An un-padded, un-hyphenated number can't be re-segmented unambiguously
+    // (is "1613584" missing a tomo zero or an asiento zero?), so anything
+    // short of 9 digits after stripping separators is rejected outright.
+    regexp: /^[1-9]\d{8}$/,
+    displayFormat: '#-####-####',
+    example: '1-0913-0259',
+    // NOTE: the cédula física has NO check digit -- Costa Rica validates it via
+    // Registro Civil / TRIBU-CR database lookup, not arithmetic. Do not add a
+    // checksum function here; there isn't one to add.
+    //
+    // TRAP: python-stdnum / stdnum-js model a *different*, 10-digit field
+    // (0P-TTTT-AAAA) where the leading digit is Hacienda's "naturaleza"
+    // (person-type) prefix -- 0=física, 1=residencia, 2=gobierno, 3=jurídica,
+    // 4=autónoma -- and is NOT part of the cédula itself. Copying that shape
+    // wrongly accepts province "0" as valid. We are deliberately stricter than
+    // stdnum here: province must be 1-9.
+    checksumAlgorithm:
+      'None -- no check digit exists; validity is confirmed via Registro Civil / TRIBU-CR database lookup, not arithmetic',
+    officialName: 'Cédula de Identidad',
+    aliasOf: null,
+    names: ['Cédula de Identidad', 'Cédula Física'],
+    links: [
+      'https://www.hacienda.go.cr/',
+      'https://en.wikipedia.org/wiki/Costa_Rican_identity_card',
+    ],
+    deprecated: false,
+  };
+
+  get METADATA(): IdMetadata {
+    return Cedula.METADATA;
+  }
+
+  static validate(value: string): boolean {
+    if (typeof value !== 'string') {
+      return false;
+    }
+
+    const cleanValue = normalize(value);
+    return Cedula.METADATA.regexp.test(cleanValue);
+  }
+
+  validate(value: string): boolean {
+    return Cedula.validate(value);
+  }
+
+  static parse(value: string): CedulaParseResult | null {
+    if (!Cedula.validate(value)) {
+      return null;
+    }
+
+    const cleanValue = normalize(value);
+    const province = parseInt(cleanValue[0], 10);
+    const tomo = cleanValue.substring(1, 5);
+    const asiento = cleanValue.substring(5, 9);
+
+    return {
+      province,
+      provinceName: PROVINCE_NAMES[province],
+      tomo,
+      asiento,
+    };
+  }
+
+  parse(value: string): CedulaParseResult | null {
+    return Cedula.parse(value);
+  }
+}

--- a/src/countries/cri/index.ts
+++ b/src/countries/cri/index.ts
@@ -1,0 +1,1 @@
+export { Cedula } from './cedula';

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,7 @@ export * as MDA from './countries/mda';
 export * as NPL from './countries/npl';
 export * as PNG from './countries/png';
 export * as SMR from './countries/smr';
+export * as CRI from './countries/cri';
 
 // Export registry
 export * from './registry';
@@ -180,6 +181,7 @@ export const SUPPORTED_COUNTRIES: CountryInfo[] = [
   { code: 'NPL', name: 'Nepal', idType: 'National ID Number' },
   { code: 'PNG', name: 'Papua New Guinea', idType: 'National ID Number' },
   { code: 'SMR', name: 'San Marino', idType: 'Social Security Number / Tax Registration' },
+  { code: 'CRI', name: 'Costa Rica', idType: 'Cédula de Identidad' },
 ];
 
 /**

--- a/src/registry/registerAll.ts
+++ b/src/registry/registerAll.ts
@@ -67,6 +67,7 @@ import { NationalID as SrbNationalID } from '../countries/srb';
 import { NationalID as TwnNationalID } from '../countries/twn';
 import { NationalID as VenNationalID } from '../countries/ven';
 import { CPFNumber } from '../countries/bra';
+import { Cedula } from '../countries/cri';
 
 // ---------------------------------------------------------------------------
 // Secondary type imports (entity IDs, old/deprecated formats — not registered
@@ -209,6 +210,7 @@ const COUNTRY_REGISTRY: RegistryEntry[] = [
   { key: 'TWN', module: TwnNationalID, aliases: ['TW'] },
   { key: 'VEN', module: VenNationalID, aliases: ['VE'] },
   { key: 'BRA', module: CPFNumber, aliases: ['BR'] },
+  { key: 'CRI', module: Cedula, aliases: ['CR'] },
 
   // --- Function-based modules ---
   { key: 'ALB', module: IdentityNumber, aliases: [] },


### PR DESCRIPTION
Closes #56.

Adds the Costa Rica Cédula de Identidad validator (`CRI` / `CR`), taking the registry to 81 countries.

## Note on sourcing

**There is no Python counterpart to port.** `~/codes/idnumbers` has no CRI module, so CLAUDE.md's "Python library is the source of truth" rule has nothing to match against here — this is net-new, and the research below is the spec.

## The headline: this ID has no check digit

**The Costa Rica cédula física has no checksum. None exists.** `checksum: false`, and there is deliberately no `checksum()` function. This isn't a gap in the implementation — it's the fact about this ID.

This is backed by negative evidence rather than mere silence:

- **Hacienda's official e-invoicing spec** details the field down to `sin guiones` and zero-padding — with zero check-digit language.
- **Costa Rica's own OECD TIN submission** — the canonical place jurisdictions publish check-digit algorithms (Spain, Italy and Brazil all do) — has none. Its only "verifying" reference is a database lookup.
- **The smoking gun:** the same spec documents a `DV` (*dígitos verificadores*) field for **DIMEX**, and none whatsoever for the cédula.
- **Structural proof:** `P(1) + TTTT(4) + AAAA(4) = 9`. Every digit is allocated. There is no spare digit to be a checksum.

Validation in Costa Rica is a Registro Civil / TRIBU-CR **lookup**, not arithmetic. A code comment says so, because if a future contributor "finds" an algorithm it will almost certainly be Ecuador's or the Dominican Republic's pattern-matched onto the wrong country — a trap that vendor sites (TaxDo, taxid.pro) have already fallen into. LookupTax explicitly rebuts them.

## Implementation

- Exactly 9 digits, `P-TTTT-AAAA` (province, tomo, asiento). Separators stripped via the existing shared `normalize()`.
- **Province `1`–`9`** — the issue's claim was right, and 1–7 would be wrong: `8` = naturalized citizens, `9` = Partida Especial (late registration / born abroad). Restricting to the seven geographic provinces would **reject every naturalized citizen and every citizen born abroad**. `0` is invalid per Hacienda's *"sin cero al inicio"*.

## Two traps, both guarded by tests

1. **The `$` anchor is load-bearing.** DIMEX numbers (11–12 digits) start with `1`, the same as San José. Without the end anchor, `/^[1-9]\d{8}/` matches the *first 9 digits* of a 12-digit DIMEX and accepts it as a person's cédula. There's a test asserting the unanchored regex *would* match while `validate()` rejects — so the anchor's necessity is asserted, not implied.
2. **Do not copy python-stdnum here.** stdnum models a *different*, 10-digit field (`0P-TTTT-AAAA`) whose leading `0` is Hacienda's *naturaleza* (person-type) prefix — `0`=física, `1`=residencia, `2`=gobierno, `3`=jurídica — and is **not part of the cédula**. Its `number[0] === '0'` check therefore validates the wrong field, which is why stdnum wrongly accepts province `0` (`0009130259` → valid). **We are deliberately stricter.**

Length alone cleanly separates física (9) from jurídica (10), NITE (10) and DIMEX (11–12); all are covered by rejection tests.

## Deliberate decision

Under-length input is **not** re-padded. stdnum notes people write cédulas with intra-group zeros omitted (`1-613-584` for `1-0613-0584`), but an un-padded number can't be re-segmented unambiguously, so anything short of 9 digits after stripping separators is rejected. Recorded in a comment and pinned by a test.

## Tests

`src/__tests__/issue-56-cri.test.ts`. `METADATA.example` is `1-0913-0259` — **Hacienda's own published example**, not a real person's number.

## Review

Shallow Codex review: **PASS**, no P0/P1/P2. The reviewer independently cited the TSE and Hacienda sources.

⚠️ Note `npm run lint` uses an unquoted glob and never lints `src/countries/**`, so green CI says nothing about these files. They were linted directly and are clean.

## Also updated

Registry (`CRI`/`CR`), `SUPPORTED_COUNTRIES`, root export, both migration tests (`80`→`81`, `CR` removed from `formerStubs`), README (counts + North America 3→4), CHANGELOG, and `package.json`'s description.

> Conflicts with #55/#57/#58 are expected — all four bump the same counters and will be rebased in merge order.
