### PR TITLE
chore(release): bump version to 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-07-27
+
 ### Added
 
 - Costa Rica (CRI) Cédula de Identidad validator — validates the 9-digit national ID (`P-TTTT-AAAA`: province 1-9, tomo, asiento); notably has no check digit, since Costa Rica confirms validity via Registro Civil / TRIBU-CR database lookup rather than arithmetic ([#56](https://github.com/identique/idnumbers-npm/issues/56))
 - Dominican Republic (DOM) Cédula de Identidad y Electoral validator — 11-digit number (series + document number + check digit) validated with a standard Luhn checksum, plus a documented 576-entry exception list (sourced from `python-stdnum`, with attribution) covering legitimately-issued cédulas — including modern 402-series cards — that fail the Luhn check; a `validate()` result of `false` means the checksum failed, not that the person does not exist ([#57](https://github.com/identique/idnumbers-npm/issues/57))
 - Ecuador (ECU) Cédula de Identidad validator — 10-digit national ID with province code (01-24, or 30 for citizens registered abroad), person-type digit (0-5, narrowed to 4-5 for the consular province 30), and a Luhn (mod 10) check digit; adds `parse()` field decomposition and registers ECU/EC in the country registry ([#55](https://github.com/identique/idnumbers-npm/issues/55))
+- Egypt (EGY) National ID (الرقم القومي) validator — 14-digit `CYYMMDDGGSSSSV` format validated against real dates and known governorate codes; the official check-digit algorithm is not publicly available, so validation is format + semantic only (`METADATA.hasChecksum = false`, in parity with the Bahrain CPR precedent), with an opt-in unverified Luhn check available via `{ strictChecksum: true }`; `parse()` extracts birth date, gender, governorate, and age ([#54](https://github.com/identique/idnumbers-npm/issues/54))
 - Guatemala (GTM) DPI/CUI (Documento Personal de Identificación) validator — 13-digit format with a mod-11 weighted-sum check digit over the 8-digit correlative, plus department and municipality validation (municipality checked against its own department, not a global maximum) ([#58](https://github.com/identique/idnumbers-npm/issues/58))
 
 ## [1.9.0] - 2026-07-17
@@ -180,7 +183,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full TypeScript support with type definitions
 - Comprehensive documentation and examples
 
-[Unreleased]: https://github.com/identique/idnumbers-npm/compare/v1.9.0...HEAD
+[Unreleased]: https://github.com/identique/idnumbers-npm/compare/v1.10.0...HEAD
+[1.10.0]: https://github.com/identique/idnumbers-npm/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/identique/idnumbers-npm/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/identique/idnumbers-npm/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/identique/idnumbers-npm/compare/v1.6.0...v1.7.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idnumbers",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "idnumbers",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idnumbers",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "A TypeScript library for verifying and parsing national ID numbers - supports 85 countries across 6 continents including USA, UK, France, Germany, Japan, China, India, Brazil, and many more",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release prep for v1.10.0, mirroring the v1.9.0 flow (#155). No code changes — only release bookkeeping.

## Contents

All 8 commits on `main` since v1.9.0, reconciled into the changelog:

- **Added** — 5 new country validators: Egypt (#54), Ecuador (#55), Costa Rica (#56), Dominican Republic (#57), Guatemala (#58)
- Contributor docs: CONTRIBUTING.md setup guide (#39), country implementation template (#40), testing/code style requirements (#41) — process docs, not user-facing library changes, so no changelog entries (consistent with 1.9.0's treatment of similar docs work)

Registry grows from **80 → 85 primary keys**; the README count and `parseIdInfo-migration` invariant are both updated accordingly.

## Version

Minor bump. Five new countries, no breaking changes to the public API.

## One gap fixed during release prep (please sanity-check)

**Egypt (#114) never got a CHANGELOG entry** — its PR didn't touch `CHANGELOG.md`. Added one now, mirroring the style of the other four country entries, sourced from `docs/research/egypt-national-id.md` and the merged PR: 14-digit `CYYMMDDGGSSSSV` format, no public check-digit algorithm (`hasChecksum: false`, Bahrain CPR precedent), opt-in unverified Luhn via `{ strictChecksum: true }`.

## Verification

Full CI gauntlet green locally: Prettier ✅ · ESLint ✅ · `tsc` build ✅ · **2345 tests / 33 suites passing** ✅ (test count already matches the README).

## After merge

Tag and release stay manual, as with v1.9.0:

```
git tag -a v1.10.0 -m "Release v1.10.0"   # on the merge commit
git push origin v1.10.0
```

Then publish a GitHub release titled `v1.10.0` with the changelog section as the body — that fires `npm-publish.yml` and pushes to npm.
